### PR TITLE
Fix shortcode extension hook removal

### DIFF
--- a/src/Shortcode/Extension.php
+++ b/src/Shortcode/Extension.php
@@ -100,16 +100,20 @@ abstract class Extension extends Singleton implements \eslin87\AlphaListing\Exte
 	 * @param int      $order The order to call this function.
 	 * @param int      $arguments The number of arguments the function expects.
 	 */
-	final protected function remove_hook( string $type, string $name, callable $function, int $order = 10, int $arguments = 1 ) {
-		$hook = array( $name, $function, $order, $arguments );
-		call_user_func_array( "remove_$type", $hook );
-		array_filter(
-			$this->filters[ $type ],
-			function( $item ) use ( $hook ) {
-				return $item === $hook;
-			}
-		);
-	}
+        final protected function remove_hook( string $type, string $name, callable $function, int $order = 10, int $arguments = 1 ) {
+                $hook = array( $name, $function, $order, $arguments );
+                call_user_func_array( "remove_$type", $hook );
+                if ( isset( $this->hooks[ $type ] ) ) {
+                        $this->hooks[ $type ] = array_values(
+                                array_filter(
+                                        $this->hooks[ $type ],
+                                        function( $item ) use ( $hook ) {
+                                                return $item !== $hook;
+                                        }
+                                )
+                        );
+                }
+        }
 
 	/**
 	 * Unhook all our filters and actions.

--- a/test/remove-hook.php
+++ b/test/remove-hook.php
@@ -1,0 +1,101 @@
+<?php
+declare(strict_types=1);
+
+if ( ! defined('ABSPATH') ) {
+    define('ABSPATH', __DIR__);
+}
+
+require_once __DIR__ . '/../src/Extension.php';
+require_once __DIR__ . '/../src/Singleton.php';
+require_once __DIR__ . '/../src/Shortcode/Extension.php';
+
+use eslin87\AlphaListing\Shortcode\Extension as BaseExtension;
+
+$GLOBALS['wp_hooks'] = array(
+    'filter' => array(),
+    'action' => array(),
+);
+
+if ( ! function_exists('add_filter') ) {
+    function add_filter( string $tag, callable $function_to_add, int $priority = 10, int $accepted_args = 1 ): void {
+        $GLOBALS['wp_hooks']['filter'][] = array( $tag, $function_to_add, $priority, $accepted_args );
+    }
+}
+
+if ( ! function_exists('remove_filter') ) {
+    function remove_filter( string $tag, callable $function_to_remove, int $priority = 10, int $accepted_args = 1 ): void {
+        $GLOBALS['wp_hooks']['filter'] = array_values(
+            array_filter(
+                $GLOBALS['wp_hooks']['filter'],
+                static function ( array $hook ) use ( $tag, $function_to_remove, $priority, $accepted_args ): bool {
+                    return $hook !== array( $tag, $function_to_remove, $priority, $accepted_args );
+                }
+            )
+        );
+    }
+}
+
+if ( ! function_exists('add_action') ) {
+    function add_action( string $tag, callable $function_to_add, int $priority = 10, int $accepted_args = 1 ): void {
+        $GLOBALS['wp_hooks']['action'][] = array( $tag, $function_to_add, $priority, $accepted_args );
+    }
+}
+
+if ( ! function_exists('remove_action') ) {
+    function remove_action( string $tag, callable $function_to_remove, int $priority = 10, int $accepted_args = 1 ): void {
+        $GLOBALS['wp_hooks']['action'] = array_values(
+            array_filter(
+                $GLOBALS['wp_hooks']['action'],
+                static function ( array $hook ) use ( $tag, $function_to_remove, $priority, $accepted_args ): bool {
+                    return $hook !== array( $tag, $function_to_remove, $priority, $accepted_args );
+                }
+            )
+        );
+    }
+}
+
+class DummyExtension extends BaseExtension {
+    public function registerFilter( callable $callable ): void {
+        $this->add_hook( 'filter', 'dummy_filter', $callable, 10, 1 );
+    }
+
+    public function unregisterFilter( callable $callable ): void {
+        $this->remove_hook( 'filter', 'dummy_filter', $callable, 10, 1 );
+    }
+
+    public function getHooks(): array {
+        return $this->hooks;
+    }
+}
+
+$extension = new DummyExtension();
+
+$callback = static function ( $value ) {
+    return $value;
+};
+
+$extension->registerFilter( $callback );
+
+$hooks = $extension->getHooks();
+
+if ( count( $hooks['filter'] ) !== 1 ) {
+    throw new RuntimeException( 'Expected one registered filter in the extension.' );
+}
+
+if ( count( $GLOBALS['wp_hooks']['filter'] ) !== 1 ) {
+    throw new RuntimeException( 'Expected one registered filter in WordPress hooks.' );
+}
+
+$extension->unregisterFilter( $callback );
+
+$hooks = $extension->getHooks();
+
+if ( ! empty( $hooks['filter'] ) ) {
+    throw new RuntimeException( 'Expected no registered filters in the extension after removal.' );
+}
+
+if ( ! empty( $GLOBALS['wp_hooks']['filter'] ) ) {
+    throw new RuntimeException( 'Expected no registered filters in WordPress hooks after removal.' );
+}
+
+fwrite( STDOUT, "remove_hook() removed the hook and updated internal state.\n" );


### PR DESCRIPTION
## Summary
- ensure `Shortcode\Extension::remove_hook()` updates the in-memory hook registry while removing hooks
- add a focused script that exercises registering and removing a dummy filter

## Testing
- php test/remove-hook.php

------
https://chatgpt.com/codex/tasks/task_b_68d19b2e4f38832cb697efe9fc509f6f