### PR TITLE
Use str_split fallback for multibyte string array

### DIFF
--- a/src/Strings.php
+++ b/src/Strings.php
@@ -38,10 +38,10 @@ class Strings {
 				},
 				range( 0, mb_strlen( $string ) - 1 )
 			);
-		} else {
-			return explode( '', $string );
-		}
-	}
+               } else {
+                       return str_split( $string );
+               }
+       }
 
 	/**
 	 * Perform a multibyte substring operation if mbstring is loaded, else use substr.


### PR DESCRIPTION
## Summary
- replace the ASCII fallback in `Strings::mb_string_to_array()` with `str_split()` so single-byte environments still split strings into characters

## Testing
- `php -r 'namespace eslin87\AlphaListing { function extension_loaded($name){return false;} function class_exists($name,$autoload=true){return false;} \define("ABSPATH", true); require "src/Strings.php"; var_export(Strings::mb_string_to_array("ABC")); }'`


------
https://chatgpt.com/codex/tasks/task_b_68d19f85f4b8832cb20276906e190f95