### PR TITLE
Fix REST shortcode handler and relocate API file

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ This file tells AI coding agents how to work safely and effectively in this repo
   - `alphalisting.php` — plugin bootstrap & headers.
   - `src/`, `templates/`, `widgets/` — main code.
   - `languages/` — translation files.
-  - `functions/`, `wp-api/`, `test/`, `css/`, `scripts/` — helpers, REST endpoints, tests, styles, build.
+  - `functions/`, `includes/`, `test/`, `css/`, `scripts/` — helpers, REST endpoints, tests, styles, build.
   - `Gruntfile.js`, `package.json`, `composer.json` — build manifests.
   - `readme.txt` — WordPress.org readme (canonical changelog lives here).
   - `.wordpress-org/` — **do not touch** (assets for WP.org distribution).

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     },
     "autoload": {
         "psr-4": {
-            "eslin87\\AlphaListing\\": ["src/", "widgets/", "wp-api/", "wp-includes/"]
+            "eslin87\\AlphaListing\\": ["src/", "widgets/", "includes/", "wp-includes/"]
         }
     },
     "scripts": {

--- a/includes/api.php
+++ b/includes/api.php
@@ -9,6 +9,38 @@
 namespace eslin87\AlphaListing;
 
 /**
+ * Proxy the shortcode renderer for REST API consumers.
+ *
+ * Normalises REST argument keys and value formats before delegating to the
+ * shortcode implementation so the REST API stays in sync with the public
+ * shortcode behaviour.
+ *
+ * @since 4.3.7
+ *
+ * @param array<string,mixed> $attributes Attributes gathered from the REST request.
+ * @return string Rendered AlphaListing markup.
+ */
+function alphalisting_shortcode_handler( array $attributes = array() ): string
+{
+        if ( isset( $attributes['post_type'] ) && ! isset( $attributes['post-type'] ) ) {
+                $attributes['post-type'] = $attributes['post_type'];
+                unset( $attributes['post_type'] );
+        }
+
+        if ( array_key_exists( 'numbers', $attributes ) ) {
+                $numbers = $attributes['numbers'];
+                if ( is_bool( $numbers ) || is_int( $numbers ) || '0' === $numbers || '1' === $numbers || 'true' === $numbers || 'false' === $numbers ) {
+                        $attributes['numbers'] = \alphalisting_is_truthy( $numbers ) ? 'after' : 'hide';
+                }
+        }
+
+        /** @var Shortcode $shortcode */
+        $shortcode = Shortcode::instance();
+
+        return $shortcode->handle( $attributes );
+}
+
+/**
  * Shared REST API handler
  *
  * @since 1.0.0

--- a/languages/alphalisting.pot
+++ b/languages/alphalisting.pot
@@ -185,31 +185,31 @@ msgstr ""
 msgid "Security check failed"
 msgstr ""
 
-#: wp-api/api.php:101
+#: includes/api.php:101
 msgid "Override default alphabet"
 msgstr ""
 
-#: wp-api/api.php:107
+#: includes/api.php:107
 msgid "Size of buckets to group the alphabet"
 msgstr ""
 
-#: wp-api/api.php:113
+#: includes/api.php:113
 msgid "Include numbers as separate group. Implies {numbers:true}"
 msgstr ""
 
-#: wp-api/api.php:118
+#: includes/api.php:118
 msgid "Taxonomy"
 msgstr ""
 
-#: wp-api/api.php:124
+#: includes/api.php:124
 msgid "Include the stylesheet tags in the output"
 msgstr ""
 
-#: wp-api/api.php:140
+#: includes/api.php:140
 msgid "Post type"
 msgstr ""
 
-#: wp-api/api.php:146
+#: includes/api.php:146
 msgid "Terms to filter by"
 msgstr ""
 

--- a/test/verify-rest-route-args.php
+++ b/test/verify-rest-route-args.php
@@ -23,7 +23,7 @@ if (!function_exists('register_rest_route')) {
         }
 }
 
-require_once __DIR__ . '/../wp-api/api.php';
+require_once __DIR__ . '/../includes/api.php';
 
 \eslin87\AlphaListing\alphalisting_register_rest_api();
 


### PR DESCRIPTION
## Summary
- add an `alphalisting_shortcode_handler()` proxy so the REST endpoints can render via the shortcode implementation and normalise REST-only parameter shapes
- move the REST API bootstrap into a new `includes/` directory and update references/autoloading accordingly
- refresh translation metadata that points at the relocated file

## Testing
- php test/verify-rest-route-args.php

------
https://chatgpt.com/codex/tasks/task_b_68d2ac028124832c88a701c70c5b0ed7