### PR TITLE
Fix localized scroll offset handling

### DIFF
--- a/scripts/alphalisting-scroll-fix.js
+++ b/scripts/alphalisting-scroll-fix.js
@@ -1,14 +1,37 @@
 ( function() {
-	const offset = a_z_listing_scroll_fix.offset || -120;
+	const settings = window.alphalisting_scroll_fix || {};
+	const offset = typeof settings.offset === 'number' ? settings.offset : -120;
+
 	function fixAlphaListingScroll() {
-		document.addEventListener( 'click', function( e ) {
-			if ( e.target.href.startsWith( '#letter-' ) ) {
-				e.preventDefault();
-				document.querySelector( e.target.href ).scrollIntoView();
+		document.addEventListener( 'click', function( event ) {
+			let target = event.target;
+
+			if ( target && target.nodeType !== 1 ) {
+				target = target.parentElement;
+			}
+
+			while ( target && target.nodeType === 1 && target.tagName !== 'A' ) {
+				target = target.parentElement;
+			}
+
+			if ( ! target || target.tagName !== 'A' ) {
+				return;
+			}
+
+			const hash = target.hash || '';
+			if ( ! hash.startsWith( '#letter-' ) ) {
+				return;
+			}
+
+			event.preventDefault();
+			const targetElement = document.querySelector( hash );
+			if ( targetElement ) {
+				targetElement.scrollIntoView();
 				window.scrollBy( 0, offset );
 			}
 		} );
 	}
+
 	if ( document.readyState === 'loading' ) {
 		document.addEventListener( 'DOMContentLoaded', fixAlphaListingScroll );
 	} else {


### PR DESCRIPTION
## Summary
- read the scroll offset from the localized `alphalisting_scroll_fix` settings object with a safe fallback
- harden the click handler to resolve anchor elements before checking hashes and applying the offset

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68d2c6e8a994832c939d5c0cb806becd