### PR TITLE
Fix exclude terms query to use term IDs

### DIFF
--- a/src/Shortcode/QueryParts/ExcludeTerms.php
+++ b/src/Shortcode/QueryParts/ExcludeTerms.php
@@ -49,7 +49,7 @@ class ExcludeTerms extends Extension {
 	public function shortcode_query_for_display_and_attribute( $query, string $display, string $key, $value, array $attributes ) {
 		$exclude_terms = Strings::maybe_mb_split( ',', $value );
 		$exclude_terms = array_map( 'trim', $exclude_terms );
-		$exclude_terms = array_map( 'intval', $exclude_terms );
+                $exclude_terms = array_map( 'intval', $exclude_terms );
 		$exclude_terms = array_filter(
 			$exclude_terms,
 			function( int $value ): bool {
@@ -67,7 +67,7 @@ class ExcludeTerms extends Extension {
 		$tax_query = array(
 			array(
 				'taxonomy' => $taxonomy,
-				'field'    => 'slug',
+                                'field'    => 'term_id',
 				'terms'    => $exclude_terms,
 				'operator' => 'NOT IN',
 			),

--- a/test/manual-exclude-terms.md
+++ b/test/manual-exclude-terms.md
@@ -1,0 +1,53 @@
+# Manual verification: `[alphalisting exclude-terms]`
+
+These steps exercise the shortcode, block, and widget flows to ensure the `exclude-terms`
+attribute removes posts assigned to the referenced taxonomy term IDs.
+
+## Prerequisites
+
+* A WordPress site with the AlphaListing plugin activated.
+* Access to create categories, posts, widgets, and pages.
+
+## Data setup
+
+1. Create two categories (or any hierarchical taxonomy terms):
+   * `Manual Keep` – note its numeric term ID (e.g. `201`).
+   * `Manual Drop` – note its numeric term ID (e.g. `202`).
+2. Create three posts:
+   * “Visible Post A” assigned only to `Manual Keep`.
+   * “Hidden Post B” assigned to both `Manual Keep` and `Manual Drop`.
+   * “Visible Post C” assigned only to `Manual Keep`.
+3. Confirm the three posts are published.
+
+## Shortcode regression check
+
+1. Create a new page containing:
+   ```
+   [alphalisting display="posts" taxonomy="category" exclude-terms="202"]
+   ```
+   (Replace `202` with the recorded term ID for `Manual Drop`.)
+2. View the page on the front end.
+3. ✅ Expected: “Hidden Post B” is missing from the listing, while “Visible Post A” and
+   “Visible Post C” remain visible.
+
+## Block UI regression check
+
+1. Add a new page and insert the **AlphaListing** block.
+2. In the block inspector, set:
+   * **Display mode** → “Posts”.
+   * **Taxonomy** → “Categories”.
+   * **Taxonomy terms** → `Manual Keep`.
+   * **Terms to exclude (IDs)** → enter the numeric ID recorded for `Manual Drop`.
+3. Update/publish the page and view it on the front end.
+4. ✅ Expected: “Hidden Post B” does not appear. The block’s saved markup shows the
+   shortcode attributes storing the numeric term ID.
+
+## Widget UI regression check
+
+1. Open *Appearance → Widgets*.
+2. Add the **AlphaListing** widget to any sidebar.
+3. Configure the widget for **Display** “Posts”, set **Taxonomy** “Categories”, and enter the
+   numeric ID for `Manual Drop` in **Terms to exclude (IDs)**.
+4. Save the widget and view a page that renders the sidebar.
+5. ✅ Expected: “Hidden Post B” is excluded from the listing while posts without the
+   excluded term remain visible.


### PR DESCRIPTION
## Summary
- update the exclude-terms shortcode query part to flag the taxonomy query as term_id-based
- document a manual regression scenario covering the shortcode, block, and widget UIs

## Testing
- php -l src/Shortcode/QueryParts/ExcludeTerms.php

------
https://chatgpt.com/codex/tasks/task_b_68d2eecfd6d4832ca754aac6f07b5f5f