### PR TITLE
feat: allow exclude-terms for term listings

### DIFF
--- a/src/Shortcode/QueryParts/ExcludeTerms.php
+++ b/src/Shortcode/QueryParts/ExcludeTerms.php
@@ -34,10 +34,10 @@ class ExcludeTerms extends Extension {
 	 * @since 4.0.0
 	 * @var array<string>
 	 */
-	public $display_types = array( 'posts' );
+        public $display_types = array( 'posts', 'terms' );
 
-	/**
-	 * Update the query with this extension's additional configuration.
+        /**
+         * Update the query with this extension's additional configuration.
 	 *
 	 * @param \AlphaListing\Query $query      The query.
 	 * @param string             $display    The display/query type.
@@ -46,38 +46,67 @@ class ExcludeTerms extends Extension {
 	 * @param array              $attributes The complete set of shortcode attributes.
 	 * @return mixed The updated query.
 	 */
-	public function shortcode_query_for_display_and_attribute( $query, string $display, string $key, $value, array $attributes ) {
-		$exclude_terms = Strings::maybe_mb_split( ',', $value );
-		$exclude_terms = array_map( 'trim', $exclude_terms );
-                $exclude_terms = array_map( 'intval', $exclude_terms );
-		$exclude_terms = array_filter(
-			$exclude_terms,
-			function( int $value ): bool {
-				return 0 < $value;
-			}
-		);
-		$exclude_terms = array_unique( $exclude_terms );
+        public function shortcode_query_for_display_and_attribute( $query, string $display, string $key, $value, array $attributes ) {
+                $exclude_terms = $this->normalize_term_ids( $value );
 
-		if ( empty( $exclude_terms ) ) {
-			return $query;
-		}
+                if ( empty( $exclude_terms ) ) {
+                        return $query;
+                }
 
-		$taxonomy = isset( $attributes['taxonomy'] ) ? $attributes['taxonomy'] : 'category';
+                if ( 'terms' === $display ) {
+                        $existing_exclusions = array();
 
-		$tax_query = array(
-			array(
-				'taxonomy' => $taxonomy,
+                        if ( isset( $query['exclude'] ) ) {
+                                $existing_exclusions = $this->normalize_term_ids( $query['exclude'] );
+                        }
+
+                        $query['exclude'] = array_values( array_unique( array_merge( $existing_exclusions, $exclude_terms ) ) );
+
+                        return $query;
+                }
+
+                $taxonomy = isset( $attributes['taxonomy'] ) ? $attributes['taxonomy'] : 'category';
+
+                $tax_query = array(
+                        array(
+                                'taxonomy' => $taxonomy,
                                 'field'    => 'term_id',
 				'terms'    => $exclude_terms,
 				'operator' => 'NOT IN',
 			),
 		);
 
-		if ( isset( $query['tax_query'] ) ) {
-			$query['tax_query'] = wp_parse_args( $query['tax_query'], $tax_query ); // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
-		} else {
-			$query['tax_query'] = $tax_query; // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
-		}
-		return $query;
-	}
+                if ( isset( $query['tax_query'] ) ) {
+                        $query['tax_query'] = wp_parse_args( $query['tax_query'], $tax_query ); // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
+                } else {
+                        $query['tax_query'] = $tax_query; // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
+                }
+                return $query;
+        }
+
+        /**
+         * Convert a value into an array of positive term IDs.
+         *
+         * @param mixed $value The raw value.
+         * @return array<int>
+         */
+        private function normalize_term_ids( $value ): array {
+                if ( is_string( $value ) ) {
+                        $value = Strings::maybe_mb_split( ',', $value );
+                } elseif ( is_int( $value ) ) {
+                        $value = array( $value );
+                } elseif ( ! is_array( $value ) ) {
+                        $value = array();
+                }
+
+                $value = array_map( 'intval', $value );
+                $value = array_filter(
+                        $value,
+                        function( int $term_id ): bool {
+                                return 0 < $term_id;
+                        }
+                );
+
+                return array_values( array_unique( $value ) );
+        }
 }

--- a/test/exclude-terms-terms-display.php
+++ b/test/exclude-terms-terms-display.php
@@ -1,0 +1,108 @@
+<?php
+declare(strict_types=1);
+
+if ( ! defined( 'ABSPATH' ) ) {
+        define( 'ABSPATH', __DIR__ );
+}
+
+require_once __DIR__ . '/../src/Extension.php';
+require_once __DIR__ . '/../src/Singleton.php';
+require_once __DIR__ . '/../src/Strings.php';
+require_once __DIR__ . '/../src/Shortcode/Extension.php';
+require_once __DIR__ . '/../src/Shortcode/Query.php';
+require_once __DIR__ . '/../src/Shortcode/TermsQuery.php';
+require_once __DIR__ . '/../src/Shortcode/QueryParts/ExcludeTerms.php';
+
+use eslin87\AlphaListing\Shortcode\QueryParts\ExcludeTerms;
+use eslin87\AlphaListing\Shortcode\TermsQuery;
+
+if ( ! class_exists( 'WP_Term' ) ) {
+        class WP_Term {
+                /** @var int */
+                public $term_id;
+
+                /** @var string */
+                public $name;
+
+                public function __construct( int $term_id, string $name ) {
+                        $this->term_id = $term_id;
+                        $this->name    = $name;
+                }
+        }
+}
+
+$all_terms = array(
+        new WP_Term( 201, 'Manual Keep' ),
+        new WP_Term( 202, 'Manual Drop' ),
+        new WP_Term( 203, 'Manual Keep Too' ),
+);
+
+if ( ! function_exists( 'get_terms' ) ) {
+        /**
+         * Mimic WordPress get_terms by filtering out excluded IDs.
+         *
+         * @param array $query The query arguments.
+         * @return array<int,WP_Term>
+         */
+        function get_terms( $query ) {
+                global $all_terms;
+
+                $exclude = array();
+                if ( isset( $query['exclude'] ) ) {
+                        $exclude = is_array( $query['exclude'] ) ? $query['exclude'] : array( $query['exclude'] );
+                }
+                $exclude = array_map( 'intval', $exclude );
+
+                return array_values(
+                        array_filter(
+                                $all_terms,
+                                static function ( WP_Term $term ) use ( $exclude ): bool {
+                                        return ! in_array( $term->term_id, $exclude, true );
+                                }
+                        )
+                );
+        }
+}
+
+$attributes = array(
+        'taxonomy'       => 'category',
+        'exclude-terms'  => '202',
+);
+
+$query = array(
+        'taxonomy' => 'category',
+        'exclude'  => array( 999 ),
+);
+
+$extension = new ExcludeTerms();
+
+$query = $extension->shortcode_query_for_display_and_attribute(
+        $query,
+        'terms',
+        'exclude-terms',
+        $attributes['exclude-terms'],
+        $attributes
+);
+
+if ( empty( $query['exclude'] ) || ! in_array( 202, $query['exclude'], true ) ) {
+        throw new RuntimeException( 'Expected the term ID to be added to the exclude list.' );
+}
+
+$terms_query = new TermsQuery();
+$items       = $terms_query->get_items( array(), $query );
+$ids         = array_map(
+        static function ( WP_Term $term ): int {
+                return $term->term_id;
+        },
+        $items
+);
+
+if ( in_array( 202, $ids, true ) ) {
+        throw new RuntimeException( 'The excluded term ID should not appear in the TermsQuery results.' );
+}
+
+if ( count( $ids ) !== 2 ) {
+        throw new RuntimeException( 'Expected only non-excluded terms to remain in the query results.' );
+}
+
+echo "TermsQuery respected exclude-terms when display=\"terms\".\n";

--- a/test/manual-exclude-terms.md
+++ b/test/manual-exclude-terms.md
@@ -1,7 +1,7 @@
 # Manual verification: `[alphalisting exclude-terms]`
 
 These steps exercise the shortcode, block, and widget flows to ensure the `exclude-terms`
-attribute removes posts assigned to the referenced taxonomy term IDs.
+attribute removes posts (and term listings) assigned to the referenced taxonomy term IDs.
 
 ## Prerequisites
 
@@ -29,6 +29,17 @@ attribute removes posts assigned to the referenced taxonomy term IDs.
 2. View the page on the front end.
 3. ✅ Expected: “Hidden Post B” is missing from the listing, while “Visible Post A” and
    “Visible Post C” remain visible.
+
+## Term listing regression check
+
+1. Create a new page containing:
+   ```
+   [alphalisting display="terms" taxonomy="category" exclude-terms="202"]
+   ```
+   (Replace `202` with the recorded term ID for `Manual Drop`.)
+2. View the page on the front end.
+3. ✅ Expected: The category picker omits the `Manual Drop` term while still listing
+   `Manual Keep` and `Manual Keep Too`.
 
 ## Block UI regression check
 


### PR DESCRIPTION
## Summary
- ensure the exclude-terms extension also runs for term listings by merging IDs into the term query's exclude argument
- add a focused PHP test that proves TermsQuery omits excluded IDs when display="terms"
- update the manual exclude-terms walkthrough with a regression check for term listings

## Testing
- php test/exclude-terms-terms-display.php

------
https://chatgpt.com/codex/tasks/task_b_68d2f81d0948832cb62a614e80cd49ee