### PR TITLE
Allow unitless zero column lengths

### DIFF
--- a/scripts/blocks/edit.js
+++ b/scripts/blocks/edit.js
@@ -4,8 +4,8 @@
  * @see https://developer.wordpress.org/block-editor/packages/packages-i18n/
  */
 
-import { useMemo } from '@wordpress/element';
-import { FormTokenField, PanelBody, Placeholder, RangeControl, SelectControl, Spinner, ToggleControl, TextControl } from '@wordpress/components';
+import { useEffect, useMemo } from '@wordpress/element';
+import { FormTokenField, PanelBody, Placeholder, RangeControl, SelectControl, Spinner, ToggleControl, TextControl, __experimentalUnitControl as UnitControl } from '@wordpress/components';
 import * as ServerSideRenderModule from '@wordpress/server-side-render';
 import { __ } from '@wordpress/i18n';
 import { InspectorControls } from '@wordpress/block-editor';
@@ -18,7 +18,7 @@ import {v4 as uuid} from 'uuid';
 /**
  * Internal dependencies
  */
-import { MAX_POSTS_COLUMNS } from './constants';
+import { MAX_COLUMN_WIDTH, MAX_POSTS_COLUMNS } from './constants';
 
 import defaults from './attributes.json';
 import ItemSelection from '../components/ItemSelection';
@@ -63,12 +63,101 @@ addFilter(
 
 const ServerSideRender = ServerSideRenderModule.ServerSideRender || ServerSideRenderModule.default;
 const displayTypes = applyFilters(
-	'alphalisting_display_types',
-	[
-		{ value: 'posts', label: __( 'Posts', 'alphalisting' ) },
-		{ value: 'terms', label: __( 'Taxonomy Terms', 'alphalisting' ) },
-	]
+        'alphalisting_display_types',
+        [
+                { value: 'posts', label: __( 'Posts', 'alphalisting' ) },
+                { value: 'terms', label: __( 'Taxonomy Terms', 'alphalisting' ) },
+        ]
 );
+
+const LENGTH_VALUE_PATTERN = /^([0-9]+(?:\.[0-9]+)?)\s*(px|em|rem|%|ch)$/i;
+const UNIT_LESS_ZERO_PATTERN = /^0+(?:\.0+)?$/;
+const LENGTH_UNITS = [
+        { value: 'px', label: 'px', step: 1, min: 0, max: MAX_COLUMN_WIDTH },
+        { value: 'em', label: 'em', step: 0.1, min: 0 },
+        { value: 'rem', label: 'rem', step: 0.1, min: 0 },
+        { value: '%', label: '%', step: 1, min: 0, max: 100 },
+        { value: 'ch', label: 'ch', step: 1, min: 0, max: 100 },
+];
+
+/**
+ * Convert an arbitrary value into a bounded integer column count.
+ *
+ * @param {unknown} value Raw attribute value.
+ * @return {number} Sanitized column count.
+ */
+const sanitizeColumnCount = ( value ) => {
+        if ( typeof value === 'number' && Number.isFinite( value ) ) {
+                value = Math.trunc( value );
+        } else if ( typeof value === 'string' && value.trim() !== '' && ! Number.isNaN( Number( value ) ) ) {
+                value = Math.trunc( Number( value ) );
+        } else {
+                value = defaults.columns.default;
+        }
+
+        if ( value < 1 ) {
+                return 1;
+        }
+
+        if ( value > MAX_POSTS_COLUMNS ) {
+                return MAX_POSTS_COLUMNS;
+        }
+
+        return value;
+};
+
+/**
+ * Ensure a CSS length string uses an allowed unit and within safe bounds.
+ *
+ * @param {unknown} value Raw attribute value.
+ * @param {string} fallback Default value when validation fails.
+ * @return {string} Sanitized CSS length string.
+ */
+const sanitizeLengthValue = ( value, fallback ) => {
+        if ( typeof value !== 'string' ) {
+                if ( typeof value === 'number' && Number.isFinite( value ) ) {
+                        value = String( value );
+                } else {
+                        return fallback;
+                }
+        }
+
+        const trimmed = value.trim();
+        if ( trimmed === '' ) {
+                return fallback;
+        }
+
+        if ( UNIT_LESS_ZERO_PATTERN.test( trimmed ) ) {
+                return '0';
+        }
+
+        const match = trimmed.match( LENGTH_VALUE_PATTERN );
+        if ( ! match ) {
+                return fallback;
+        }
+
+        const numeric = Number.parseFloat( match[ 1 ] );
+        const unit = match[ 2 ].toLowerCase();
+
+        if ( ! Number.isFinite( numeric ) || numeric < 0 ) {
+                return fallback;
+        }
+
+        let bounded = numeric;
+        if ( unit === 'px' ) {
+                bounded = Math.min( bounded, MAX_COLUMN_WIDTH );
+        }
+
+        if ( unit === '%' || unit === 'ch' ) {
+                bounded = Math.min( bounded, 100 );
+        }
+
+        if ( Number.isInteger( bounded ) ) {
+                return `${ bounded }${ unit }`;
+        }
+
+        return `${ parseFloat( bounded.toFixed( 4 ) ) }${ unit }`;
+};
 
 const A_Z_Listing_Edit = ( { attributes, setAttributes } ) => {
 	const { postTypes, allTaxonomies } = useSelect( ( select ) => {
@@ -127,18 +216,55 @@ const A_Z_Listing_Edit = ( { attributes, setAttributes } ) => {
 		);
 	}, [ allTaxonomies ] );
 
-	const validationErrors = useMemo( () => {
-		const errors = [];
-		if ( 'terms' === attributes.display && ! attributes.taxonomy ) {
-			errors.push(
-				__(
+        const validationErrors = useMemo( () => {
+                const errors = [];
+                if ( 'terms' === attributes.display && ! attributes.taxonomy ) {
+                        errors.push(
+                                __(
 					`You must set a taxonomy when display mode is set to 'terms'.`,
 					'alphalisting'
 				)
 			);
-		}
-		return errors;
-	}, [ attributes.display, attributes.taxonomy ] );
+                }
+                return errors;
+        }, [ attributes.display, attributes.taxonomy ] );
+
+        const sanitizedColumns = useMemo(
+                () => sanitizeColumnCount( attributes.columns ),
+                [ attributes.columns ]
+        );
+        const sanitizedColumnWidth = useMemo(
+                () => sanitizeLengthValue(
+                        attributes['column-width'] ?? defaults['column-width'].default,
+                        defaults['column-width'].default
+                ),
+                [ attributes['column-width'] ]
+        );
+        const sanitizedColumnGap = useMemo(
+                () => sanitizeLengthValue(
+                        attributes['column-gap'] ?? defaults['column-gap'].default,
+                        defaults['column-gap'].default
+                ),
+                [ attributes['column-gap'] ]
+        );
+
+        useEffect( () => {
+                if ( typeof attributes.columns !== 'undefined' && attributes.columns !== sanitizedColumns ) {
+                        setAttributes( { columns: sanitizedColumns } );
+                }
+        }, [ attributes.columns, sanitizedColumns, setAttributes ] );
+
+        useEffect( () => {
+                if ( typeof attributes['column-width'] !== 'undefined' && attributes['column-width'] !== sanitizedColumnWidth ) {
+                        setAttributes( { 'column-width': sanitizedColumnWidth } );
+                }
+        }, [ attributes['column-width'], sanitizedColumnWidth, setAttributes ] );
+
+        useEffect( () => {
+                if ( typeof attributes['column-gap'] !== 'undefined' && attributes['column-gap'] !== sanitizedColumnGap ) {
+                        setAttributes( { 'column-gap': sanitizedColumnGap } );
+                }
+        }, [ attributes['column-gap'], sanitizedColumnGap, setAttributes ] );
 
 
 	const inspectorControls = (
@@ -369,39 +495,49 @@ const A_Z_Listing_Edit = ( { attributes, setAttributes } ) => {
 											__nextHasNoMarginBottom
 										/>
 
-										<RangeControl
-											label={ __( 'Columns', 'alphalisting' ) }
-											value={ attributes.columns ?? MAX_POSTS_COLUMNS }
-											onChange={ ( value ) =>
-												setAttributes( { columns: value } )
-											}
-											min={ 1 }
-											max={ MAX_POSTS_COLUMNS }
-											withInputField
-											required
-											__next40pxDefaultSize
-											__nextHasNoMarginBottom
-										/>
-										<TextControl
-											label={ __( 'Column width', 'alphalisting' ) }
-											value={ attributes['column-width'] ?? defaults['column-width'].default }
-											onChange={ ( value ) =>
-												setAttributes( { 'column-width': value } )
-											}
-											required
-											__next40pxDefaultSize
-											__nextHasNoMarginBottom
-										/>
-										<TextControl
-											label={ __( 'Column gap', 'alphalisting' ) }
-											value={ attributes['column-gap'] ?? defaults['column-gap'].default }
-											onChange={ ( value ) =>
-												setAttributes( { 'column-gap': value } )
-											}
-											required
-											__next40pxDefaultSize
-											__nextHasNoMarginBottom
-										/>
+                                                                                <RangeControl
+                                                                                        label={ __( 'Columns', 'alphalisting' ) }
+                                                                                        value={ sanitizedColumns }
+                                                                                        onChange={ ( value ) =>
+                                                                                                setAttributes( { columns: sanitizeColumnCount( value ) } )
+                                                                                        }
+                                                                                        min={ 1 }
+                                                                                        max={ MAX_POSTS_COLUMNS }
+                                                                                        withInputField
+                                                                                        required
+                                                                                        __next40pxDefaultSize
+                                                                                        __nextHasNoMarginBottom
+                                                                                />
+                                                                                <UnitControl
+                                                                                        label={ __( 'Column width', 'alphalisting' ) }
+                                                                                        value={ sanitizedColumnWidth }
+                                                                                        units={ LENGTH_UNITS }
+                                                                                        onChange={ ( nextValue ) =>
+                                                                                                setAttributes( {
+                                                                                                        'column-width': sanitizeLengthValue(
+                                                                                                                nextValue,
+                                                                                                                defaults['column-width'].default
+                                                                                                        ),
+                                                                                                } )
+                                                                                        }
+                                                                                        __next40pxDefaultSize
+                                                                                        __nextHasNoMarginBottom
+                                                                                />
+                                                                                <UnitControl
+                                                                                        label={ __( 'Column gap', 'alphalisting' ) }
+                                                                                        value={ sanitizedColumnGap }
+                                                                                        units={ LENGTH_UNITS }
+                                                                                        onChange={ ( nextValue ) =>
+                                                                                                setAttributes( {
+                                                                                                        'column-gap': sanitizeLengthValue(
+                                                                                                                nextValue,
+                                                                                                                defaults['column-gap'].default
+                                                                                                        ),
+                                                                                                } )
+                                                                                        }
+                                                                                        __next40pxDefaultSize
+                                                                                        __nextHasNoMarginBottom
+                                                                                />
 
 										{ subFills }
 									</>

--- a/src/Shortcode/QueryParts/ColumnGap.php
+++ b/src/Shortcode/QueryParts/ColumnGap.php
@@ -19,36 +19,52 @@ use \eslin87\AlphaListing\Shortcode\Extension;
  * Column Gap Query Part extension
  */
 class ColumnGap extends Extension {
-	/**
-	 * The attribute for this Query Part.
-	 *
-	 * @since 4.0.0
-	 * @var string
-	 */
-	public $attribute_name = 'column-gap';
+        private const ALLOWED_UNITS = array( 'px', 'em', 'rem', '%', 'ch' );
+        private const MAX_PIXEL_VALUE = 1200.0;
+        private const MAX_PERCENT_VALUE = 100.0;
+        public const DEFAULT_COLUMN_GAP = '0.6em';
 
-	/**
-	 * The column gap.
-	 *
-	 * @var string
-	 */
-	public $column_gap = '0.6em';
+        /**
+         * The attribute for this Query Part.
+         *
+         * @since 4.0.0
+         * @var string
+         */
+        public $attribute_name = 'column-gap';
 
-	/**
-	 * Update the query with this extension's additional configuration.
-	 *
-	 * @param \AlphaListing\Query $query      The query.
+        /**
+         * The column gap.
+         *
+         * @var string
+         */
+        public $column_gap = self::DEFAULT_COLUMN_GAP;
+
+        /**
+         * Sanitize the shortcode attribute.
+         *
+         * @param mixed $value      The value of the shortcode attribute.
+         * @param array $attributes The complete set of shortcode attributes.
+         * @return string
+         */
+        public function sanitize_attribute( $value, array $attributes ) {
+                return $this->sanitize_css_length( $value, self::DEFAULT_COLUMN_GAP );
+        }
+
+        /**
+         * Update the query with this extension's additional configuration.
+         *
+         * @param \AlphaListing\Query $query      The query.
 	 * @param string             $display    The display/query type.
 	 * @param string             $key        The name of the attribute.
 	 * @param mixed              $value      The shortcode attribute value.
 	 * @param array              $attributes The complete set of shortcode attributes.
 	 * @return mixed The updated query.
 	 */
-	public function shortcode_query( $query, string $display, string $key, $value, array $attributes ) {
-		$this->column_gap = $value;
-		$this->add_hook( 'filter', 'alphalisting_styles', array( $this, 'return_styles' ), 10, 3 );
-		return $query;
-	}
+        public function shortcode_query( $query, string $display, string $key, $value, array $attributes ) {
+                $this->column_gap = $this->sanitize_css_length( $value, self::DEFAULT_COLUMN_GAP );
+                $this->add_hook( 'filter', 'alphalisting_styles', array( $this, 'return_styles' ), 10, 3 );
+                return $query;
+        }
 
 	/**
 	 * Return the stylesheet for this instance.
@@ -58,7 +74,77 @@ class ColumnGap extends Extension {
 	 * @param string             $instance_id The instance ID.
 	 * @return string
 	 */
-	public function return_styles( $styles, $alphalisting, $instance_id ): string {
-		return "$styles --alphalisting-column-gap: $this->column_gap; ";
-	}
+        public function return_styles( $styles, $alphalisting, $instance_id ): string {
+                return sprintf(
+                        '%s --alphalisting-column-gap: %s; ',
+                        $styles,
+                        $this->column_gap
+                );
+        }
+
+        /**
+         * Ensure the provided column gap is a safe CSS length value.
+         *
+         * @param mixed  $value   Potential CSS length value.
+         * @param string $default Default value to use when sanitization fails.
+         * @return string
+         */
+        private function sanitize_css_length( $value, string $default ): string {
+                if ( is_string( $value ) ) {
+                        $value = trim( $value );
+                } elseif ( is_numeric( $value ) ) {
+                        $value = (string) $value;
+                } else {
+                        return $default;
+                }
+
+                if ( '' === $value ) {
+                        return $default;
+                }
+
+                if ( preg_match( '/^0+(?:\.0+)?$/', $value ) ) {
+                        return '0';
+                }
+
+                if ( ! preg_match( '/^([0-9]+(?:\.[0-9]+)?)\s*(px|em|rem|%|ch)$/i', $value, $matches ) ) {
+                        return $default;
+                }
+
+                $number = (float) $matches[1];
+                $unit   = strtolower( $matches[2] );
+
+                if ( ! in_array( $unit, self::ALLOWED_UNITS, true ) ) {
+                        return $default;
+                }
+
+                if ( $number < 0 ) {
+                        return $default;
+                }
+
+                if ( 'px' === $unit ) {
+                        $number = min( $number, self::MAX_PIXEL_VALUE );
+                }
+
+                if ( in_array( $unit, array( '%', 'ch' ), true ) ) {
+                        $number = min( $number, self::MAX_PERCENT_VALUE );
+                }
+
+                $number_string = $this->format_numeric_value( $number );
+
+                return $number_string . $unit;
+        }
+
+        /**
+         * Normalize numeric values before concatenating with units.
+         *
+         * @param float $number The numeric value to format.
+         * @return string
+         */
+        private function format_numeric_value( float $number ): string {
+                if ( floor( $number ) === $number ) {
+                        return (string) (int) $number;
+                }
+
+                return rtrim( rtrim( sprintf( '%.4f', $number ), '0' ), '.' );
+        }
 }

--- a/src/Shortcode/QueryParts/ColumnWidth.php
+++ b/src/Shortcode/QueryParts/ColumnWidth.php
@@ -19,6 +19,10 @@ use \eslin87\AlphaListing\Shortcode\Extension;
  * Column Width Query Part extension
  */
 class ColumnWidth extends Extension {
+        private const ALLOWED_UNITS = array( 'px', 'em', 'rem', '%', 'ch' );
+        private const MAX_PIXEL_VALUE = 1200.0;
+        private const MAX_PERCENT_VALUE = 100.0;
+        public const DEFAULT_COLUMN_WIDTH = '15em';
 	/**
 	 * The attribute for this Query Part.
 	 *
@@ -27,12 +31,23 @@ class ColumnWidth extends Extension {
 	 */
 	public $attribute_name = 'column-width';
 
-	/**
-	 * The column width.
-	 *
-	 * @var string
-	 */
-	public $column_width = '15em';
+        /**
+         * The column width.
+         *
+         * @var string
+         */
+        public $column_width = self::DEFAULT_COLUMN_WIDTH;
+
+        /**
+         * Sanitize the shortcode attribute.
+         *
+         * @param mixed $value      The value of the shortcode attribute.
+         * @param array $attributes The complete set of shortcode attributes.
+         * @return string
+         */
+        public function sanitize_attribute( $value, array $attributes ) {
+                return $this->sanitize_css_length( $value, self::DEFAULT_COLUMN_WIDTH );
+        }
 
 	/**
 	 * Update the query with this extension's additional configuration.
@@ -44,11 +59,11 @@ class ColumnWidth extends Extension {
 	 * @param array              $attributes The complete set of shortcode attributes.
 	 * @return mixed The updated query.
 	 */
-	public function shortcode_query( $query, string $display, string $key, $value, array $attributes ) {
-		$this->column_width = $value;
-		$this->add_hook( 'filter', 'alphalisting_styles', array( $this, 'return_styles' ), 10, 3 );
-		return $query;
-	}
+        public function shortcode_query( $query, string $display, string $key, $value, array $attributes ) {
+                $this->column_width = $this->sanitize_css_length( $value, self::DEFAULT_COLUMN_WIDTH );
+                $this->add_hook( 'filter', 'alphalisting_styles', array( $this, 'return_styles' ), 10, 3 );
+                return $query;
+        }
 
 	/**
 	 * Return the stylesheet for this instance.
@@ -58,7 +73,77 @@ class ColumnWidth extends Extension {
 	 * @param string             $instance_id The instance ID.
 	 * @return string
 	 */
-	public function return_styles( $styles, $alphalisting, $instance_id ): string {
-		return "$styles --alphalisting-column-width: $this->column_width; ";
-	}
+        public function return_styles( $styles, $alphalisting, $instance_id ): string {
+                return sprintf(
+                        '%s --alphalisting-column-width: %s; ',
+                        $styles,
+                        $this->column_width
+                );
+        }
+
+        /**
+         * Ensure the provided column width is a safe CSS length value.
+         *
+         * @param mixed  $value   Potential CSS length value.
+         * @param string $default Default value to use when sanitization fails.
+         * @return string
+         */
+        private function sanitize_css_length( $value, string $default ): string {
+                if ( is_string( $value ) ) {
+                        $value = trim( $value );
+                } elseif ( is_numeric( $value ) ) {
+                        $value = (string) $value;
+                } else {
+                        return $default;
+                }
+
+                if ( '' === $value ) {
+                        return $default;
+                }
+
+                if ( preg_match( '/^0+(?:\.0+)?$/', $value ) ) {
+                        return '0';
+                }
+
+                if ( ! preg_match( '/^([0-9]+(?:\.[0-9]+)?)\s*(px|em|rem|%|ch)$/i', $value, $matches ) ) {
+                        return $default;
+                }
+
+                $number = (float) $matches[1];
+                $unit   = strtolower( $matches[2] );
+
+                if ( ! in_array( $unit, self::ALLOWED_UNITS, true ) ) {
+                        return $default;
+                }
+
+                if ( $number < 0 ) {
+                        return $default;
+                }
+
+                if ( 'px' === $unit ) {
+                        $number = min( $number, self::MAX_PIXEL_VALUE );
+                }
+
+                if ( in_array( $unit, array( '%', 'ch' ), true ) ) {
+                        $number = min( $number, self::MAX_PERCENT_VALUE );
+                }
+
+                $number_string = $this->format_numeric_value( $number );
+
+                return $number_string . $unit;
+        }
+
+        /**
+         * Normalize numeric values before concatenating with units.
+         *
+         * @param float $number The numeric value to format.
+         * @return string
+         */
+        private function format_numeric_value( float $number ): string {
+                if ( floor( $number ) === $number ) {
+                        return (string) (int) $number;
+                }
+
+                return rtrim( rtrim( sprintf( '%.4f', $number ), '0' ), '.' );
+        }
 }

--- a/src/Shortcode/QueryParts/Columns.php
+++ b/src/Shortcode/QueryParts/Columns.php
@@ -19,38 +19,53 @@ use \eslin87\AlphaListing\Shortcode\Extension;
  * Columns Query Part extension
  */
 class Columns extends Extension {
-	/**
-	 * The attribute for this Query Part.
-	 *
-	 * @since 4.0.0
-	 * @var string
-	 */
-	public $attribute_name = 'columns';
+        public const DEFAULT_COLUMN_COUNT = 3;
+        public const MIN_COLUMN_COUNT = 1;
+        public const MAX_COLUMN_COUNT = 15;
 
-	/**
-	 * The number of columns.
-	 *
-	 * @var int
-	 */
-	public $columns = 3;
+        /**
+         * The attribute for this Query Part.
+         *
+         * @since 4.0.0
+         * @var string
+         */
+        public $attribute_name = 'columns';
 
-	/**
-	 * Update the query with this extension's additional configuration.
-	 *
-	 * @param \AlphaListing\Query $query      The query.
+        /**
+         * The number of columns.
+         *
+         * @var int
+         */
+        public $columns = self::DEFAULT_COLUMN_COUNT;
+
+        /**
+         * Sanitize the shortcode attribute.
+         *
+         * @param mixed $value      The value of the shortcode attribute.
+         * @param array $attributes The complete set of shortcode attributes.
+         * @return int
+         */
+        public function sanitize_attribute( $value, array $attributes ) {
+                return $this->sanitize_column_count( $value );
+        }
+
+        /**
+         * Update the query with this extension's additional configuration.
+         *
+         * @param \AlphaListing\Query $query      The query.
 	 * @param string             $display    The display/query type.
 	 * @param string             $key        The name of the attribute.
 	 * @param mixed              $value      The shortcode attribute value.
 	 * @param array              $attributes The complete set of shortcode attributes.
 	 * @return mixed The updated query.
 	 */
-	public function shortcode_query( $query, string $display, string $key, $value, array $attributes ) {
-		$this->columns = $value;
-		$this->add_hook( 'filter', 'alphalisting_styles', array( $this, 'return_styles' ), 10, 3 );
-		return $query;
-	}
+        public function shortcode_query( $query, string $display, string $key, $value, array $attributes ) {
+                $this->columns = $this->sanitize_column_count( $value );
+                $this->add_hook( 'filter', 'alphalisting_styles', array( $this, 'return_styles' ), 10, 3 );
+                return $query;
+        }
 
-	/**
+        /**
 	 * Return the stylesheet for this instance.
 	 *
 	 * @param string             $styles      The stylesheet.
@@ -58,7 +73,43 @@ class Columns extends Extension {
 	 * @param string             $instance_id The instance ID.
 	 * @return string
 	 */
-	public function return_styles( $styles, $alphalisting, $instance_id ): string {
-		return "$styles --alphalisting-column-count: $this->columns; ";
-	}
+        public function return_styles( $styles, $alphalisting, $instance_id ): string {
+                return sprintf(
+                        '%s --alphalisting-column-count: %d; ',
+                        $styles,
+                        $this->columns
+                );
+        }
+
+        /**
+         * Ensure the provided column count is a safe integer.
+         *
+         * @param mixed $value Potential column count.
+         * @return int
+         */
+        protected function sanitize_column_count( $value ): int {
+                if ( is_string( $value ) ) {
+                        $value = trim( $value );
+                }
+
+                if ( '' === $value || null === $value ) {
+                        return self::DEFAULT_COLUMN_COUNT;
+                }
+
+                if ( is_numeric( $value ) ) {
+                        $value = (int) floor( (float) $value );
+                } else {
+                        return self::DEFAULT_COLUMN_COUNT;
+                }
+
+                if ( $value < self::MIN_COLUMN_COUNT ) {
+                        return self::MIN_COLUMN_COUNT;
+                }
+
+                if ( $value > self::MAX_COLUMN_COUNT ) {
+                        return self::MAX_COLUMN_COUNT;
+                }
+
+                return $value;
+        }
 }

--- a/test/column-sanitization.php
+++ b/test/column-sanitization.php
@@ -1,0 +1,110 @@
+<?php
+declare(strict_types=1);
+
+if ( ! defined( 'ABSPATH' ) ) {
+        define( 'ABSPATH', __DIR__ );
+}
+
+require_once __DIR__ . '/../src/Extension.php';
+require_once __DIR__ . '/../src/Singleton.php';
+require_once __DIR__ . '/../src/Shortcode/Extension.php';
+require_once __DIR__ . '/../src/Shortcode/QueryParts/Columns.php';
+require_once __DIR__ . '/../src/Shortcode/QueryParts/ColumnGap.php';
+require_once __DIR__ . '/../src/Shortcode/QueryParts/ColumnWidth.php';
+
+use eslin87\AlphaListing\Shortcode\QueryParts\ColumnGap;
+use eslin87\AlphaListing\Shortcode\QueryParts\Columns;
+use eslin87\AlphaListing\Shortcode\QueryParts\ColumnWidth;
+
+if ( ! function_exists( 'add_filter' ) ) {
+        function add_filter( $hook, $callback, $priority = 10, $accepted_args = 1 ) { // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound
+                return true;
+        }
+}
+
+if ( ! function_exists( 'remove_filter' ) ) {
+        function remove_filter( $hook, $callback, $priority = 10, $accepted_args = 1 ) { // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound
+                return true;
+        }
+}
+
+/**
+ * Simple assertion helper.
+ *
+ * @param mixed  $expected Expected value.
+ * @param mixed  $actual   Actual value.
+ * @param string $message  Error message on failure.
+ * @return void
+ */
+function assert_same( $expected, $actual, string $message ): void {
+        if ( $expected !== $actual ) {
+                throw new RuntimeException( $message . sprintf( ' Expected %s, got %s.', var_export( $expected, true ), var_export( $actual, true ) ) );
+        }
+}
+
+/**
+ * Assert that a string contains the expected substring.
+ *
+ * @param string $needle   Expected substring.
+ * @param string $haystack Full string to inspect.
+ * @param string $message  Error message on failure.
+ * @return void
+ */
+function assert_contains( string $needle, string $haystack, string $message ): void {
+        if ( strpos( $haystack, $needle ) === false ) {
+                throw new RuntimeException( $message . sprintf( ' Expected %s within %s.', var_export( $needle, true ), var_export( $haystack, true ) ) );
+        }
+}
+
+$columns = new Columns();
+assert_same( 12, $columns->sanitize_attribute( '12', array() ), 'Column count should sanitize numeric strings.' );
+assert_same( Columns::MAX_COLUMN_COUNT, $columns->sanitize_attribute( '999', array() ), 'Column count should clamp to the maximum.' );
+assert_same( Columns::DEFAULT_COLUMN_COUNT, $columns->sanitize_attribute( 'calc(2*3)', array() ), 'Column count should fall back for invalid input.' );
+
+$columns->shortcode_query( array(), 'posts', 'columns', '4', array() );
+$column_count_styles = $columns->return_styles( ' ', null, 'test' );
+assert_contains( '--alphalisting-column-count: 4;', $column_count_styles, 'Styles should include sanitized column count.' );
+
+$columns_invalid = new Columns();
+$columns_invalid->shortcode_query( array(), 'posts', 'columns', 'calc(2*3)', array() );
+$column_count_invalid_styles = $columns_invalid->return_styles( ' ', null, 'test' );
+assert_contains( '--alphalisting-column-count: ' . Columns::DEFAULT_COLUMN_COUNT . ';', $column_count_invalid_styles, 'Invalid column count should revert to default in styles.' );
+
+$column_width = new ColumnWidth();
+assert_same( '1200px', $column_width->sanitize_attribute( '1500px', array() ), 'Column width should clamp pixel values.' );
+assert_same( ColumnWidth::DEFAULT_COLUMN_WIDTH, $column_width->sanitize_attribute( 'calc(10px)', array() ), 'Column width should reject unsafe tokens.' );
+assert_same( '0', $column_width->sanitize_attribute( '0', array() ), 'Column width should allow unitless zero.' );
+
+$column_width->shortcode_query( array(), 'posts', 'column-width', '1500px', array() );
+$column_width_styles = $column_width->return_styles( ' ', null, 'test' );
+assert_contains( '--alphalisting-column-width: 1200px;', $column_width_styles, 'Styles should reflect clamped column width.' );
+
+$column_width_zero = new ColumnWidth();
+$column_width_zero->shortcode_query( array(), 'posts', 'column-width', '0', array() );
+$column_width_zero_styles = $column_width_zero->return_styles( ' ', null, 'test' );
+assert_contains( '--alphalisting-column-width: 0;', $column_width_zero_styles, 'Unitless zero column width should be preserved.' );
+
+$column_gap = new ColumnGap();
+assert_same( '100%', $column_gap->sanitize_attribute( '500%', array() ), 'Column gap should clamp percentage values.' );
+assert_same( ColumnGap::DEFAULT_COLUMN_GAP, $column_gap->sanitize_attribute( 'url(javascript:alert(1))', array() ), 'Column gap should reject unsafe tokens.' );
+assert_same( '0', $column_gap->sanitize_attribute( '0', array() ), 'Column gap should allow unitless zero.' );
+
+$column_gap->shortcode_query( array(), 'posts', 'column-gap', '12%', array() );
+$column_gap_styles = $column_gap->return_styles( ' ', null, 'test' );
+assert_contains( '--alphalisting-column-gap: 12%;', $column_gap_styles, 'Styles should use sanitized column gap.' );
+
+$column_gap_zero = new ColumnGap();
+$column_gap_zero->shortcode_query( array(), 'posts', 'column-gap', '0', array() );
+$column_gap_zero_styles = $column_gap_zero->return_styles( ' ', null, 'test' );
+assert_contains( '--alphalisting-column-gap: 0;', $column_gap_zero_styles, 'Unitless zero column gap should be preserved.' );
+
+$column_gap_invalid = new ColumnGap();
+$column_gap_invalid->shortcode_query( array(), 'posts', 'column-gap', 'calc(1+1)', array() );
+$column_gap_invalid_styles = $column_gap_invalid->return_styles( ' ', null, 'test' );
+assert_contains( '--alphalisting-column-gap: ' . ColumnGap::DEFAULT_COLUMN_GAP . ';', $column_gap_invalid_styles, 'Invalid column gap should revert to default in styles.' );
+
+// Extra coverage for rem/em rounding.
+$column_gap_rounding = new ColumnGap();
+assert_same( '0.125em', $column_gap_rounding->sanitize_attribute( '0.1250em', array() ), 'Column gap should normalize fractional em values.' );
+
+echo "Column-related shortcode attributes are sanitized and safe.\n";


### PR DESCRIPTION
## Summary
- allow unitless zero values for shortcode column gap and width so legitimate zero spacing is preserved
- update block editor sanitization to accept unitless zero column settings
- extend the column sanitization regression test to cover unitless zero inputs

## Testing
- php test/column-sanitization.php

------
https://chatgpt.com/codex/tasks/task_b_690cf525c6f48321b6e5ac1b3f6e7d14