### PR TITLE
Fix parent selector refresh for hierarchical post types

### DIFF
--- a/scripts/components/PostParent.js
+++ b/scripts/components/PostParent.js
@@ -28,8 +28,8 @@ function getTitle( post ) {
 export function PostParent( { pageId, postTypeSlug, onChange } ) {
 	const [ fieldValue, setFieldValue ] = useState( '' );
 	const isSearching = fieldValue;
-	const { parentPost, parentPostId, items, postType } = useSelect(
-		( select ) => {
+        const { parentPost, parentPostId, items, postType } = useSelect(
+                ( select ) => {
 			const { getPostType, getEntityRecords, getEntityRecord } = select(
 				'core'
 			);
@@ -57,9 +57,9 @@ export function PostParent( { pageId, postTypeSlug, onChange } ) {
 					: [],
 				postType: pType,
 			};
-		},
-		[ fieldValue ]
-	);
+                },
+                [ fieldValue, pageId, postTypeSlug ]
+        );
 
 	const isHierarchical = get( postType, [ 'hierarchical' ], false );
 	const pageItems = items || [];
@@ -99,7 +99,7 @@ export function PostParent( { pageId, postTypeSlug, onChange } ) {
 			} );
 		}
 		return opts;
-	}, [ pageItems ] );
+        }, [ pageItems, parentPost, parentPostId, isSearching ] );
 
 	if ( ! isHierarchical ) {
 		return null;


### PR DESCRIPTION
## Summary
- ensure the post parent selector re-queries when the post type or selected parent changes
- keep the parent combobox options in sync with parent lookups and search state

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_690d2785af5c8321a16d8e440f6b5c5d