### PR TITLE
Fix get_item_meta to handle plural item prefixes

### DIFF
--- a/src/Query.php
+++ b/src/Query.php
@@ -917,15 +917,20 @@ class Query {
 	 * @return mixed|\WP_Error Will be an array if $single is false. Will be value of meta data field if $single is true.
 	 */
 	public function get_item_meta( string $key = '', bool $single = false ) {
-		if ( is_string( $this->current_item['item'] ) ) {
-			$item = explode( ':', $this->current_item['item'], 2 );
+                if ( is_string( $this->current_item['item'] ) ) {
+                        $item = explode( ':', $this->current_item['item'], 2 );
 
-			if ( 'term' === $item[0] ) {
-				return get_term_meta( intval( $item[1] ), $key, $single );
-			} elseif ( 'post' === $item[0] ) {
-				return get_post_meta( intval( $item[1] ), $key, $single );
-			}
-		} elseif ( $this->current_item['item'] instanceof \WP_Term ) {
+                        if ( isset( $item[1] ) ) {
+                                $prefix = $item[0];
+                                $item_id = intval( $item[1] );
+
+                                if ( in_array( $prefix, array( 'term', 'terms' ), true ) ) {
+                                        return get_term_meta( $item_id, $key, $single );
+                                } elseif ( in_array( $prefix, array( 'post', 'posts' ), true ) ) {
+                                        return get_post_meta( $item_id, $key, $single );
+                                }
+                        }
+                } elseif ( $this->current_item['item'] instanceof \WP_Term ) {
 			return get_term_meta( $this->current_item['item']->term_id, $key, $single );
 		} elseif ( $this->current_item['item'] instanceof \WP_Post ) {
 			return get_post_meta( $this->current_item['item']->ID, $key, $single );

--- a/test/get-item-meta.php
+++ b/test/get-item-meta.php
@@ -1,0 +1,101 @@
+<?php
+declare(strict_types=1);
+
+if ( ! defined('ABSPATH') ) {
+    define('ABSPATH', __DIR__);
+}
+
+require_once __DIR__ . '/../src/Query.php';
+
+use eslin87\AlphaListing\Query;
+
+if ( ! class_exists('WP_Error') ) {
+    class WP_Error {
+        public function __construct( $code = '', $message = '' ) {
+            $this->code = $code;
+            $this->message = $message;
+        }
+    }
+}
+
+if ( ! function_exists('get_post_meta') ) {
+    function get_post_meta( int $post_id, string $key = '', bool $single = false ) {
+        return array(
+            'type'   => 'post',
+            'id'     => $post_id,
+            'key'    => $key,
+            'single' => $single,
+        );
+    }
+}
+
+if ( ! function_exists('get_term_meta') ) {
+    function get_term_meta( int $term_id, string $key = '', bool $single = false ) {
+        return array(
+            'type'   => 'term',
+            'id'     => $term_id,
+            'key'    => $key,
+            'single' => $single,
+        );
+    }
+}
+
+$reflection = new ReflectionClass( Query::class );
+$query = $reflection->newInstanceWithoutConstructor();
+
+$current_item_property = $reflection->getProperty( 'current_item' );
+$current_item_property->setAccessible( true );
+
+$current_item_property->setValue(
+    $query,
+    array(
+        'item' => 'term:15',
+    )
+);
+
+$term_meta = $query->get_item_meta( 'term_key', true );
+
+if ( $term_meta['type'] !== 'term' || $term_meta['id'] !== 15 ) {
+    throw new RuntimeException( 'Expected term meta to be returned for the "term" prefix.' );
+}
+
+$current_item_property->setValue(
+    $query,
+    array(
+        'item' => 'terms:25',
+    )
+);
+
+$terms_meta = $query->get_item_meta( 'term_key', false );
+
+if ( $terms_meta['type'] !== 'term' || $terms_meta['id'] !== 25 ) {
+    throw new RuntimeException( 'Expected term meta to be returned for the "terms" prefix.' );
+}
+
+$current_item_property->setValue(
+    $query,
+    array(
+        'item' => 'post:35',
+    )
+);
+
+$post_meta = $query->get_item_meta( 'post_key', true );
+
+if ( $post_meta['type'] !== 'post' || $post_meta['id'] !== 35 ) {
+    throw new RuntimeException( 'Expected post meta to be returned for the "post" prefix.' );
+}
+
+$current_item_property->setValue(
+    $query,
+    array(
+        'item' => 'posts:45',
+    )
+);
+
+$posts_meta = $query->get_item_meta( 'post_key', false );
+
+if ( $posts_meta['type'] !== 'post' || $posts_meta['id'] !== 45 ) {
+    throw new RuntimeException( 'Expected post meta to be returned for the "posts" prefix.' );
+}
+
+echo "get_item_meta() returns metadata for plural and singular prefixes.\n";


### PR DESCRIPTION
## Summary
- ensure Query::get_item_meta() recognizes the plural `posts` and `terms` prefixes created by the index builder
- keep support for singular prefixes so existing integrations continue to work
- add a regression test that exercises both plural and singular prefixes when fetching metadata

## Testing
- php test/get-item-meta.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_690e493056788321aa9de3af7838fa0e)