### PR TITLE
fix: harden widget update sanitization

### DIFF
--- a/test/widget-update-sanitization.php
+++ b/test/widget-update-sanitization.php
@@ -1,0 +1,116 @@
+<?php
+declare(strict_types=1);
+
+if ( ! defined( 'ABSPATH' ) ) {
+        define( 'ABSPATH', __DIR__ );
+}
+
+if ( ! class_exists( 'WP_Widget' ) ) {
+        /**
+         * Minimal WP_Widget stub for isolated tests.
+         */
+        class WP_Widget { // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound
+                public function __construct( $id_base = '', $name = '', $widget_options = array(), $control_options = array() ) {
+                }
+
+                public function get_field_id( $field_name ) {
+                        return $field_name;
+                }
+
+                public function get_field_name( $field_name ) {
+                        return $field_name;
+                }
+        }
+}
+
+if ( ! function_exists( 'add_action' ) ) {
+        function add_action( $hook, $callback, $priority = 10, $accepted_args = 1 ) { // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound
+                return true;
+        }
+}
+
+if ( ! function_exists( '__' ) ) {
+        function __( $text, $domain = null ) { // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound
+                return $text;
+        }
+}
+
+if ( ! function_exists( 'wp_strip_all_tags' ) ) {
+        function wp_strip_all_tags( $text ) { // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound
+                return trim( strip_tags( (string) $text ) );
+        }
+}
+
+require_once __DIR__ . '/../widgets/class-alphalisting-widget.php';
+
+use eslin87\AlphaListing\AlphaListing_Widget;
+
+/**
+ * Simple assertion helper.
+ *
+ * @param mixed  $expected Expected value.
+ * @param mixed  $actual   Actual value.
+ * @param string $message  Error message on failure.
+ * @return void
+ */
+function assert_same( $expected, $actual, string $message ): void {
+        if ( $expected !== $actual ) {
+                throw new RuntimeException( $message . sprintf( ' Expected %s, got %s.', var_export( $expected, true ), var_export( $actual, true ) ) );
+        }
+}
+
+/**
+ * Assert that a value is empty.
+ *
+ * @param mixed  $actual  Actual value.
+ * @param string $message Error message on failure.
+ * @return void
+ */
+function assert_empty( $actual, string $message ): void {
+        if ( ! empty( $actual ) ) {
+                throw new RuntimeException( $message . sprintf( ' Got %s.', var_export( $actual, true ) ) );
+        }
+}
+
+$widget = new AlphaListing_Widget();
+
+$old_instance = array(
+        'all_children'     => 'true',
+        'hide_empty_terms' => 'true',
+        'parent_term'      => 'should reset',
+        'terms'            => '1,2,3',
+        'exclude_terms'    => '4,5',
+);
+
+$new_instance = array(
+        'title'     => '  <strong>Updated Listing</strong> ',
+        'type'      => 'terms',
+        'post'      => '17',
+        'post_type' => 'page',
+        'taxonomy'  => 'category',
+        // Intentionally omit optional text fields and checkboxes to confirm defaults.
+);
+
+$errors = array();
+set_error_handler(
+        function ( $errno, $errstr ) use ( &$errors ) {
+                if ( in_array( $errno, array( E_WARNING, E_NOTICE, E_USER_WARNING, E_USER_NOTICE ), true ) ) {
+                        $errors[] = $errstr;
+                }
+
+                return true;
+        }
+);
+
+$updated = $widget->update( $new_instance, $old_instance );
+
+restore_error_handler();
+
+assert_empty( $errors, 'Widget update should not trigger notices or warnings when optional values are omitted.' );
+assert_same( 'false', $updated['all_children'], 'Unchecked all_children checkbox should default to string false.' );
+assert_same( 'false', $updated['hide_empty_terms'], 'Unchecked hide_empty_terms checkbox should default to string false.' );
+assert_same( '', $updated['parent_term'], 'Missing parent term should sanitize to an empty string.' );
+assert_same( '', $updated['terms'], 'Missing include terms should sanitize to an empty string.' );
+assert_same( '', $updated['exclude_terms'], 'Missing exclude terms should sanitize to an empty string.' );
+
+echo "AlphaListing widget update handles unchecked inputs without notices.\n";

--- a/widgets/class-alphalisting-widget.php
+++ b/widgets/class-alphalisting-widget.php
@@ -313,31 +313,36 @@ class AlphaListing_Widget extends \WP_Widget {
 	 * @param  array<string,mixed> $old_instance the previous configuration values.
 	 * @return array<string,mixed> sanitised version of the new configuration values to be saved
 	 */
-	public function update( $new_instance, $old_instance ) {
-		$instance = $old_instance;
+    public function update( $new_instance, $old_instance ) {
+            $instance = $old_instance;
 
-		$instance['title']             = wp_strip_all_tags( $new_instance['title'] );
-		$instance['type']              = wp_strip_all_tags( $new_instance['type'] );
-		$instance['post']              = (int) $new_instance['post']; // target.
-		$instance['target_post_title'] = wp_strip_all_tags( $new_instance['target_post_title'] );
-		$instance['post_type']         = wp_strip_all_tags( $new_instance['post_type'] );
-		$instance['taxonomy']          = wp_strip_all_tags( $new_instance['taxonomy'] );
-		$instance['parent_post']       = (int) $new_instance['parent_post'];
-		$instance['all_children']      = 'on' === $new_instance['all_children'] ? 'true' : 'false';
-		$instance['parent_term']       = wp_strip_all_tags( $new_instance['parent_term'] );
-		$instance['terms']             = wp_strip_all_tags( $new_instance['terms'] );
-		$instance['exclude_terms']     = wp_strip_all_tags( $new_instance['exclude_terms'] );
-		$instance['hide_empty_terms']  = 'on' === $new_instance['hide_empty_terms'] ? 'true' : 'false';
+            $target_post_title  = wp_strip_all_tags( $new_instance['target_post_title'] ?? '' );
+            $parent_post_title  = wp_strip_all_tags( $new_instance['parent_post_title'] ?? '' );
+            $all_children_input = $new_instance['all_children'] ?? '';
+            $hide_empty_input   = $new_instance['hide_empty_terms'] ?? '';
 
-		if ( empty( $new_instance['target_post_title'] ) ) {
-			$instance['post'] = 0;
-		}
-		if ( empty( $new_instance['parent_post_title'] ) ) {
-			$instance['parent_post'] = 0;
-		}
+            $instance['title']             = wp_strip_all_tags( $new_instance['title'] ?? '' );
+            $instance['type']              = wp_strip_all_tags( $new_instance['type'] ?? '' );
+            $instance['post']              = (int) ( $new_instance['post'] ?? 0 ); // target.
+            $instance['target_post_title'] = $target_post_title;
+            $instance['post_type']         = wp_strip_all_tags( $new_instance['post_type'] ?? '' );
+            $instance['taxonomy']          = wp_strip_all_tags( $new_instance['taxonomy'] ?? '' );
+            $instance['parent_post']       = (int) ( $new_instance['parent_post'] ?? 0 );
+            $instance['all_children']      = 'on' === $all_children_input ? 'true' : 'false';
+            $instance['parent_term']       = wp_strip_all_tags( $new_instance['parent_term'] ?? '' );
+            $instance['terms']             = wp_strip_all_tags( $new_instance['terms'] ?? '' );
+            $instance['exclude_terms']     = wp_strip_all_tags( $new_instance['exclude_terms'] ?? '' );
+            $instance['hide_empty_terms']  = 'on' === $hide_empty_input ? 'true' : 'false';
 
-		return $instance;
-	}
+            if ( '' === $target_post_title ) {
+                    $instance['post'] = 0;
+            }
+            if ( '' === $parent_post_title ) {
+                    $instance['parent_post'] = 0;
+            }
+
+            return $instance;
+    }
 
 	/**
 	 * Print the user-visible widget to the page


### PR DESCRIPTION
## Summary
- guard AlphaListing_Widget::update() against missing form fields and default checkbox/text values safely
- reset target and parent post IDs when their companion titles are empty after sanitization
- add a regression test that exercises widget updates with unchecked checkboxes and missing optional text inputs

## Testing
- php test/widget-update-sanitization.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_690e48d6e10083219f781b4042818dd2)