### PR TITLE
fix: prevent PHP 8 TypeError in alphalisting_styles callbacks

### DIFF
--- a/src/Shortcode/QueryParts/ColumnGap.php
+++ b/src/Shortcode/QueryParts/ColumnGap.php
@@ -70,9 +70,11 @@ class ColumnGap extends Extension {
      * Return the stylesheet for this instance.
      *
      * @param string             $styles      The stylesheet.
+     * @param mixed              $query       The listing query instance passed by the filter.
+     * @param mixed              $instance_id The listing instance id passed by the filter.
      * @return string
      */
-    public function return_styles($styles): string  {
+    public function return_styles($styles, $query = null, $instance_id = null): string  {
         return sprintf('%s --alphalisting-column-gap: %s; ', $styles, $this->column_gap);
     }
 

--- a/src/Shortcode/QueryParts/ColumnWidth.php
+++ b/src/Shortcode/QueryParts/ColumnWidth.php
@@ -70,9 +70,11 @@ class ColumnWidth extends Extension {
      * Return the stylesheet for this instance.
      *
      * @param string             $styles      The stylesheet.
+     * @param mixed              $query       The listing query instance passed by the filter.
+     * @param mixed              $instance_id The listing instance id passed by the filter.
      * @return string
      */
-    public function return_styles($styles): string {
+    public function return_styles($styles, $query = null, $instance_id = null): string {
         return sprintf('%s --alphalisting-column-width: %s; ', $styles, $this->column_width);
     }
 

--- a/src/Shortcode/QueryParts/Columns.php
+++ b/src/Shortcode/QueryParts/Columns.php
@@ -75,9 +75,11 @@ class Columns extends Extension {
      * Return the stylesheet for this instance.
      *
      * @param string    $styles      The stylesheet.
+     * @param mixed     $query       The listing query instance passed by the filter.
+     * @param mixed     $instance_id The listing instance id passed by the filter.
      * @return string
      */
-    public function return_styles($styles): string {
+    public function return_styles($styles, $query = null, $instance_id = null): string {
         return sprintf(
             "%s --alphalisting-column-count: %d; ",
             $styles,


### PR DESCRIPTION
## Summary
- Updated `ColumnWidth::return_styles`, `ColumnGap::return_styles`, and `Columns::return_styles` to accept the extra filter arguments passed by `apply_filters( 'alphalisting_styles', '', $this, $this->instance_id )`.
- Kept behavior unchanged by making the additional parameters optional and unused.
- Added docblock parameter entries for the filter-provided query and instance id arguments.

## Why
`alphalisting_styles` is registered with `accepted_args = 3`, and `Query::get_customized_column_styles()` passes three arguments. Under PHP 8, callbacks that only accepted one argument raised a `TypeError` and broke shortcode/block rendering.

## Validation
- `php -l src/Shortcode/QueryParts/ColumnWidth.php`
- `php -l src/Shortcode/QueryParts/ColumnGap.php`
- `php -l src/Shortcode/QueryParts/Columns.php`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d54e33e6e08321916e91db359818a5)