### PR TITLE
feat: add configurable back-to-top shortcode/block attribute

### DIFF
--- a/alphalisting.php
+++ b/alphalisting.php
@@ -58,6 +58,7 @@ function alphalisting_init() {
 
 	// Shortcode attribute handlers.
 	\eslin87\AlphaListing\Shortcode\QueryParts\Alphabet::instance()->activate( __FILE__ )->initialize();
+	\eslin87\AlphaListing\Shortcode\QueryParts\BackToTop::instance()->activate( __FILE__ )->initialize();
 	\eslin87\AlphaListing\Shortcode\QueryParts\Columns::instance()->activate( __FILE__ )->initialize();
 	\eslin87\AlphaListing\Shortcode\QueryParts\ColumnGap::instance()->activate( __FILE__ )->initialize();
 	\eslin87\AlphaListing\Shortcode\QueryParts\ColumnWidth::instance()->activate( __FILE__ )->initialize();

--- a/scripts/blocks/attributes.json
+++ b/scripts/blocks/attributes.json
@@ -47,6 +47,10 @@
         "type": "boolean",
         "default": false
     },
+    "back-to-top": {
+        "type": "boolean",
+        "default": true
+    },
     "post-type": {
         "type": "string",
         "default": "page"

--- a/scripts/blocks/edit.js
+++ b/scripts/blocks/edit.js
@@ -747,6 +747,15 @@ const A_Z_Listing_Edit = ( { attributes, setAttributes } ) => {
 											__next40pxDefaultSize
 											__nextHasNoMarginBottom
 										/>
+										<ToggleControl
+											label={ __( 'Show back to top link', 'alphalisting' ) }
+											checked={ !! attributes['back-to-top'] }
+											onChange={ ( value ) =>
+												setAttributes( { 'back-to-top': value } )
+											}
+											__next40pxDefaultSize
+											__nextHasNoMarginBottom
+										/>
 
 										<RangeControl
 											label={ __( 'Columns', 'alphalisting' ) }

--- a/src/Shortcode.php
+++ b/src/Shortcode.php
@@ -48,6 +48,7 @@ class Shortcode extends Singleton implements Extension {
 		$defaults   = apply_filters(
 			'alphalisting_get_shortcode_attributes',
 			array(
+				'back-to-top'      => 'true',
 				'display'          => 'posts',
 				'get-all-children' => 'false',
 				'group-numbers'    => '',

--- a/src/Shortcode/QueryParts/BackToTop.php
+++ b/src/Shortcode/QueryParts/BackToTop.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * Back To Top Query Part.
+ *
+ * @package alphalisting
+ */
+
+declare(strict_types=1);
+
+namespace eslin87\AlphaListing\Shortcode\QueryParts;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+use \eslin87\AlphaListing\Shortcode\Extension;
+
+/**
+ * Back To Top Query Part extension.
+ */
+class BackToTop extends Extension {
+    /**
+     * The attribute for this Query Part.
+     *
+     * @since 4.3.9
+     * @var string
+     */
+    public $attribute_name = 'back-to-top';
+
+    /**
+     * The default value for this Query Part.
+     *
+     * @since 4.3.9
+     * @var string
+     */
+    public $default_value = 'true';
+
+    /**
+     * Resolved "back to top" visibility for this listing.
+     *
+     * @var bool
+     */
+    protected $show_back_to_top = true;
+
+    /**
+     * Sanitize the shortcode attribute.
+     *
+     * @param mixed $value      The value of the shortcode attribute.
+     * @param array $attributes The complete set of shortcode attributes.
+     * @return string
+     */
+    public function sanitize_attribute( $value, array $attributes ) {
+        return alphalisting_is_truthy( $value ) ? 'true' : 'false';
+    }
+
+    /**
+     * Update the query with this extension's additional configuration.
+     *
+     * @param mixed  $query      The query.
+     * @param string $display    The display/query type.
+     * @param string $key        The name of the attribute.
+     * @param mixed  $value      The shortcode attribute value.
+     * @param array  $attributes The complete set of shortcode attributes.
+     * @return mixed The updated query.
+     */
+    public function shortcode_query( $query, string $display, string $key, $value, array $attributes ) {
+        $this->show_back_to_top = alphalisting_is_truthy( $value );
+        $this->add_hook( 'filter', 'alphalisting_show_back_to_top', array( $this, 'return_show_back_to_top' ), 10, 2 );
+        return $query;
+    }
+
+    /**
+     * Return whether "Back to top" should be rendered.
+     *
+     * @param bool $show Whether to show the link.
+     * @return bool
+     */
+    public function return_show_back_to_top( bool $show ): bool {
+        return $this->show_back_to_top;
+    }
+}

--- a/templates/a-z-listing.example.php
+++ b/templates/a-z-listing.example.php
@@ -46,11 +46,13 @@
 							<?php endwhile; ?>
 						</ul>
 
-						<div class="back-to-top">
-							<a href="#<?php $a_z_query->the_instance_id(); ?>">
-								<?php esc_html_e( 'Back to top', 'alphalisting' ); ?>
-							</a>
-						</div>
+						<?php if ( apply_filters( 'alphalisting_show_back_to_top', true, $a_z_query ) ) : ?>
+							<div class="back-to-top">
+								<a href="#<?php $a_z_query->the_instance_id(); ?>">
+									<?php esc_html_e( 'Back to top', 'alphalisting' ); ?>
+								</a>
+							</div>
+						<?php endif; ?>
 					</div>
 				<?php endif; ?>
 			<?php endwhile; ?>

--- a/templates/a-z-listing.php
+++ b/templates/a-z-listing.php
@@ -67,14 +67,16 @@ $a_z_listing_minpercol = 10;
 							<?php endwhile; ?>
 						</ul>
 
-						<div class="back-to-top">
-							<a href="#<?php $a_z_query->the_instance_id(); ?>">
-								<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-up" viewBox="0 0 16 16">
-									<path fill-rule="evenodd" d="M7.646 4.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1-.708.708L8 5.707l-5.646 5.647a.5.5 0 0 1-.708-.708z"/>
-								</svg>
-								<?php esc_html_e( 'Back to top', 'alphalisting' ); ?>
-							</a>
-						</div>
+						<?php if ( apply_filters( 'alphalisting_show_back_to_top', true, $a_z_query ) ) : ?>
+							<div class="back-to-top">
+								<a href="#<?php $a_z_query->the_instance_id(); ?>">
+									<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-up" viewBox="0 0 16 16">
+										<path fill-rule="evenodd" d="M7.646 4.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1-.708.708L8 5.707l-5.646 5.647a.5.5 0 0 1-.708-.708z"/>
+									</svg>
+									<?php esc_html_e( 'Back to top', 'alphalisting' ); ?>
+								</a>
+							</div>
+						<?php endif; ?>
 					</div>
 					<?php
 				endif;


### PR DESCRIPTION
### Motivation

- Provide a public, backward-compatible way to control the per-letter "Back to top" link so authors can opt out when needed while keeping existing shortcode output unchanged.

### Description

- Added a new default shortcode attribute `'back-to-top' => 'true'` in `src/Shortcode.php` so existing `[alphalisting]` instances continue to show the link by default.
- Implemented `src/Shortcode/QueryParts/BackToTop.php` as a query-part extension that registers the `back-to-top` attribute, sanitizes it to strict `'true'`/`'false'`, and exposes the resolved value through the `alphalisting_show_back_to_top` filter.
- Registered `BackToTop` during plugin bootstrap in `alphalisting.php` alongside other shortcode query parts and updated templates (`templates/a-z-listing.php` and `templates/a-z-listing.example.php`) to conditionally render the link via `apply_filters( 'alphalisting_show_back_to_top', true, $a_z_query )`.
- Added block support by adding a boolean `back-to-top` attribute (default `true`) to `scripts/blocks/attributes.json` and adding a `ToggleControl` labeled "Show back to top link" in `scripts/blocks/edit.js`; `scripts/blocks/shortcode-upgrader.js` already forwards parsed shortcode attributes so no change was needed there.

### Testing

- Ran PHP linting on modified PHP files with `php -l` for `src/Shortcode.php`, `src/Shortcode/QueryParts/BackToTop.php`, `alphalisting.php`, `templates/a-z-listing.php`, and `templates/a-z-listing.example.php`, and all reported no syntax errors.
- Verified `scripts/blocks/attributes.json` parses as valid JSON with `node -e "JSON.parse(require('fs').readFileSync('scripts/blocks/attributes.json','utf8'))"`, which succeeded.
- No unit test suite is present; changes were validated via the above automated checks only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d5595a7dd48321a3a8fffd7cc1a890)