### PR TITLE
fix: preserve shortcode attributes when converting shortcode blocks

### DIFF
--- a/scripts/blocks/attributes.json
+++ b/scripts/blocks/attributes.json
@@ -52,8 +52,11 @@
         "default": true
     },
     "post-type": {
-        "type": "string",
-        "default": "page"
+        "type": "array",
+        "items": {
+            "type": "string"
+        },
+        "default": ["page"]
     },
     "exclude-posts": {
         "type": "array",

--- a/scripts/blocks/attributes.json
+++ b/scripts/blocks/attributes.json
@@ -52,11 +52,7 @@
         "default": true
     },
     "post-type": {
-        "type": "array",
-        "items": {
-            "type": "string"
-        },
-        "default": ["page"]
+        "default": "page"
     },
     "exclude-posts": {
         "type": "array",

--- a/scripts/blocks/edit.js
+++ b/scripts/blocks/edit.js
@@ -35,7 +35,7 @@ addFilter(
 	'alphalisting',
 	( attributes ) => ( {
 		...attributes,
-		'post-type': defaults['post-type'].default,
+		'post-type': [ ...defaults['post-type'].default ],
 		taxonomy: defaults.taxonomy.default,
 		terms: [ ...defaults.terms.default ],
 		'exclude-posts': [ ...defaults['exclude-posts'].default ],
@@ -263,6 +263,20 @@ const sanitizeStringTokenList = ( values ) => {
 	return Array.from( new Set( sanitized ) );
 };
 
+/**
+ * Normalize selected post types into unique string slugs.
+ *
+ * @param {unknown} values Raw attribute value.
+ * @return {string[]} Sanitized post type slugs.
+ */
+const sanitizePostTypeList = ( values ) => {
+	if ( typeof values === 'string' ) {
+		values = values.split( ',' );
+	}
+
+	return sanitizeStringTokenList( values );
+};
+
 const A_Z_Listing_Edit = ( { attributes, setAttributes } ) => {
 	const { postTypes, allTaxonomies } = useSelect( ( select ) => {
 		const { getPostTypes, getTaxonomies } = select( coreStore );
@@ -301,8 +315,12 @@ const A_Z_Listing_Edit = ( { attributes, setAttributes } ) => {
 
 	const postTypesTaxonomiesSelectOptions = useMemo( () => {
 		let postTaxonomies = [];
-		if ( attributes['display'] === 'posts' && attributes['post-type'] && postTypesTaxonomiesMap ) {
-			postTaxonomies = postTypesTaxonomiesMap[ attributes['post-type'] ] || [];
+		const selectedPostTypes = sanitizePostTypeList( attributes['post-type'] ?? defaults['post-type'].default );
+		if ( attributes['display'] === 'posts' && selectedPostTypes.length > 0 && postTypesTaxonomiesMap ) {
+			postTaxonomies = selectedPostTypes.flatMap(
+				( postType ) => postTypesTaxonomiesMap[ postType ] || []
+			);
+			postTaxonomies = Array.from( new Set( postTaxonomies ) );
 		}
 		return [ { label: '', slug: '' } ].concat(
 			allTaxonomies
@@ -312,7 +330,7 @@ const A_Z_Listing_Edit = ( { attributes, setAttributes } ) => {
 					value: tax.slug,
 				} ) )
 		);
-	}, [ attributes['post-type'], postTypesTaxonomiesMap, allTaxonomies ]);
+	}, [ attributes.display, attributes['post-type'], postTypesTaxonomiesMap, allTaxonomies ]);
 
 	const taxonomiesSelectOptions = useMemo( () => {
 		return [ { label: '', slug: '' } ].concat(
@@ -425,6 +443,18 @@ const A_Z_Listing_Edit = ( { attributes, setAttributes } ) => {
 		}
 	}, [ attributes.terms, attributes.display, setAttributes ] );
 
+	useEffect( () => {
+		if ( typeof attributes['post-type'] === 'undefined' ) {
+			return;
+		}
+
+		const sanitized = sanitizePostTypeList( attributes['post-type'] );
+
+		if ( JSON.stringify( sanitized ) !== JSON.stringify( attributes['post-type'] ) ) {
+			setAttributes( { 'post-type': sanitized } );
+		}
+	}, [ attributes['post-type'], setAttributes ] );
+
 	const excludePostsTokens = useMemo(
 		() => sanitizeNumericTokenList( attributes['exclude-posts'] ).map( ( token ) => token.toString() ),
 		[ attributes['exclude-posts'] ]
@@ -434,6 +464,13 @@ const A_Z_Listing_Edit = ( { attributes, setAttributes } ) => {
 		() => sanitizeNumericTokenList( attributes['exclude-terms'] ).map( ( token ) => token.toString() ),
 		[ attributes['exclude-terms'] ]
 	);
+	const selectedPostTypes = useMemo(
+		() => sanitizePostTypeList( attributes['post-type'] ?? defaults['post-type'].default ),
+		[ attributes['post-type'] ]
+	);
+	const selectedPostTypeForParent = selectedPostTypes.length === 1
+		? selectedPostTypes[ 0 ]
+		: '';
 
 	const parentTermValue = typeof attributes['parent-term'] === 'undefined'
 		? defaults['parent-term'].default
@@ -470,16 +507,17 @@ const A_Z_Listing_Edit = ( { attributes, setAttributes } ) => {
 										{ 'posts' === attributes.display && (
 											<SelectControl
 												label={ __( 'Post Type', 'alphalisting' ) }
-												value={ attributes['post-type'] ?? defaults['post-type'].default }
+												value={ selectedPostTypes }
 												options={ postTypesSelectOptions }
 												onChange={ ( value ) =>
 													setAttributes(
 														applyFilters(
 															'alphalisting_selection_changed_for__post-type',
-															{ 'post-type': value }
+															{ 'post-type': sanitizePostTypeList( value ) }
 														)
 													)
 												}
+												multiple
 												__next40pxDefaultSize
 												__nextHasNoMarginBottom
 											/>
@@ -487,11 +525,12 @@ const A_Z_Listing_Edit = ( { attributes, setAttributes } ) => {
 
 										{ (
 											'posts' === attributes.display &&
-											postTypesMap && postTypesMap[ attributes['post-type'] ]?.hierarchical
+											selectedPostTypeForParent &&
+											postTypesMap && postTypesMap[ selectedPostTypeForParent ]?.hierarchical
 										) && (
 											<PostParent
 												pageId={ attributes['parent-post'] ?? defaults['parent-post'].default }
-												postTypeSlug={ attributes['post-type'] ?? defaults['post-type'].default }
+												postTypeSlug={ selectedPostTypeForParent }
 												onChange={ ( parentId ) => setAttributes( { 'parent-post': parentId } ) }
 											/>
 										) }

--- a/scripts/blocks/edit.js
+++ b/scripts/blocks/edit.js
@@ -35,7 +35,7 @@ addFilter(
 	'alphalisting',
 	( attributes ) => ( {
 		...attributes,
-		'post-type': [ ...defaults['post-type'].default ],
+		'post-type': defaults['post-type'].default,
 		taxonomy: defaults.taxonomy.default,
 		terms: [ ...defaults.terms.default ],
 		'exclude-posts': [ ...defaults['exclude-posts'].default ],
@@ -449,9 +449,13 @@ const A_Z_Listing_Edit = ( { attributes, setAttributes } ) => {
 		}
 
 		const sanitized = sanitizePostTypeList( attributes['post-type'] );
+		const normalized = sanitized.join( ',' );
+		const current = Array.isArray( attributes['post-type'] )
+			? attributes['post-type'].join( ',' )
+			: String( attributes['post-type'] ?? '' ).trim();
 
-		if ( JSON.stringify( sanitized ) !== JSON.stringify( attributes['post-type'] ) ) {
-			setAttributes( { 'post-type': sanitized } );
+		if ( normalized !== current ) {
+			setAttributes( { 'post-type': normalized } );
 		}
 	}, [ attributes['post-type'], setAttributes ] );
 
@@ -513,7 +517,7 @@ const A_Z_Listing_Edit = ( { attributes, setAttributes } ) => {
 													setAttributes(
 														applyFilters(
 															'alphalisting_selection_changed_for__post-type',
-															{ 'post-type': sanitizePostTypeList( value ) }
+															{ 'post-type': sanitizePostTypeList( value ).join( ',' ) }
 														)
 													)
 												}

--- a/scripts/blocks/edit.js
+++ b/scripts/blocks/edit.js
@@ -302,7 +302,7 @@ const A_Z_Listing_Edit = ( { attributes, setAttributes } ) => {
 	const postTypesTaxonomiesSelectOptions = useMemo( () => {
 		let postTaxonomies = [];
 		if ( attributes['display'] === 'posts' && attributes['post-type'] && postTypesTaxonomiesMap ) {
-			postTaxonomies = postTypesTaxonomiesMap[ attributes['post-type'] ];
+			postTaxonomies = postTypesTaxonomiesMap[ attributes['post-type'] ] || [];
 		}
 		return [ { label: '', slug: '' } ].concat(
 			allTaxonomies

--- a/scripts/blocks/index.js
+++ b/scripts/blocks/index.js
@@ -10,7 +10,6 @@ import { createReduxStore, register } from '@wordpress/data';
 import domReady from '@wordpress/dom-ready';
 import { applyFilters } from '@wordpress/hooks';
 import { postList as icon } from '@wordpress/icons';
-import { attrs } from '@wordpress/shortcode';
 
 import edit from './edit';
 import globalAttributes from './attributes.json';
@@ -20,105 +19,106 @@ import Extensions from '../components/Extensions';
 import AZInspectorControls from '../components/AZInspectorControls';
 
 import shortcodeUpgrader from './shortcode-upgrader';
+import { parseShortcodeAttributes } from './shortcode-attributes';
 
 const store = createReduxStore( 'alphalisting/slotfills', {
-	reducer( state = {} ) {
-		return state;
-	},
-	selectors: {
-		getDisplayOptions() {
-			return DisplayOptions;
-		},
-		getItemSelection() {
-			return ItemSelection;
-		},
-		getExtensions() {
-			return Extensions;
-		},
-		getInspectorControls() {
-			return AZInspectorControls;
-		},
-	},
+    reducer( state = {} ) {
+        return state;
+    },
+    selectors: {
+        getDisplayOptions() {
+            return DisplayOptions;
+        },
+        getItemSelection() {
+            return ItemSelection;
+        },
+        getExtensions() {
+            return Extensions;
+        },
+        getInspectorControls() {
+            return AZInspectorControls;
+        },
+    },
 } );
 register( store );
 
 domReady( () => {
-	const attributes = applyFilters( 'alphalisting_attributes', globalAttributes );
+    const attributes = applyFilters( 'alphalisting_attributes', globalAttributes );
 
-	/**
-	 * Every block starts by registering a new block type definition.
-	 *
-	 * @see https://developer.wordpress.org/block-editor/developers/block-api/#registering-a-block
-	 */
-	registerBlockType( 'alphalisting/block', {
-		/**
-		 * This is the display title for your block, which can be translated with `i18n` functions.
-		 * The block inserter will show this name.
-		 */
-		title: __( 'AlphaListing', 'alphalisting' ),
+    /**
+     * Every block starts by registering a new block type definition.
+     *
+     * @see https://developer.wordpress.org/block-editor/developers/block-api/#registering-a-block
+     */
+    registerBlockType( 'alphalisting/block', {
+        /**
+         * This is the display title for your block, which can be translated with `i18n` functions.
+         * The block inserter will show this name.
+         */
+        title: __( 'AlphaListing', 'alphalisting' ),
 
-		/**
-		 * This is a short description for your block, can be translated with `i18n` functions.
-		 * It will be shown in the Block Tab in the Settings Sidebar.
-		 */
-		description: __(
-			'Show your posts in an alphabetically-ordered rolodex-style list',
-			'alphalisting'
-		),
+        /**
+         * This is a short description for your block, can be translated with `i18n` functions.
+         * It will be shown in the Block Tab in the Settings Sidebar.
+         */
+        description: __(
+            'Show your posts in an alphabetically-ordered rolodex-style list',
+            'alphalisting'
+        ),
 
-		/**
-		 * Blocks are grouped into categories to help users browse and discover them.
-		 * The categories provided by core are `common`, `embed`, `formatting`, `layout` and `widgets`.
-		 */
-		category: 'widgets',
+        /**
+         * Blocks are grouped into categories to help users browse and discover them.
+         * The categories provided by core are `common`, `embed`, `formatting`, `layout` and `widgets`.
+         */
+        category: 'widgets',
 
-		/**
-		 * An icon property should be specified to make it easier to identify a block.
-		 * These can be any of WordPress’ Dashicons, or a custom svg element.
-		 */
-		icon,
+        /**
+         * An icon property should be specified to make it easier to identify a block.
+         * These can be any of WordPress’ Dashicons, or a custom svg element.
+         */
+        icon,
 
-		/**
-		 * Optional block extended support features.
-		 */
-		supports: {
-			align: true,
-			html: false,
-		},
+        /**
+         * Optional block extended support features.
+         */
+        supports: {
+            align: true,
+            html: false,
+        },
 
-		attributes,
+        attributes,
 
-		edit,
+        edit,
 
-		save: () => null,
+        save: () => null,
 
-		transforms: {
-			from: [
-				{
-					type: 'prefix',
-					prefix: '[alphalisting',
-					transform() {
-						return createBlock( 'alphalisting/block' );
-					},
-				},
-				{
-					type: 'prefix',
-					prefix: '[alphalisting]',
-					transform() {
-						return createBlock( 'alphalisting/block' );
-					},
-				},
-				{
-					type: 'raw',
-					isMatch: ( node ) => node.nodeName === 'P' && /^\s*\[alphalisting.*\]\s*$/.test( node.textContent ),
-					transform( node ) {
-						const atts = attrs( node.textContent.trim() );
-						return createBlock( 'alphalisting/block', atts );
-					},
-				},
-			],
-		},
-	} );
+        transforms: {
+            from: [
+                {
+                    type: 'prefix',
+                    prefix: '[alphalisting',
+                    transform() {
+                        return createBlock( 'alphalisting/block' );
+                    },
+                },
+                {
+                    type: 'prefix',
+                    prefix: '[alphalisting]',
+                    transform() {
+                        return createBlock( 'alphalisting/block' );
+                    },
+                },
+                {
+                    type: 'raw',
+                    isMatch: ( node ) => node.nodeName === 'P' && /^\s*\[alphalisting.*\]\s*$/.test( node.textContent ),
+                    transform( node ) {
+                        const attributes = parseShortcodeAttributes( node.textContent.trim() );
+                        return createBlock( 'alphalisting/block', attributes );
+                    },
+                },
+            ],
+        },
+    } );
 
-	shortcodeUpgrader();
+    shortcodeUpgrader();
 } );

--- a/scripts/blocks/index.js
+++ b/scripts/blocks/index.js
@@ -19,7 +19,7 @@ import Extensions from '../components/Extensions';
 import AZInspectorControls from '../components/AZInspectorControls';
 
 import shortcodeUpgrader from './shortcode-upgrader';
-import { canConvertShortcodeToBlock, parseShortcodeAttributes } from './shortcode-attributes';
+import { parseShortcodeAttributes } from './shortcode-attributes';
 
 const store = createReduxStore( 'alphalisting/slotfills', {
     reducer( state = {} ) {
@@ -112,8 +112,7 @@ domReady( () => {
                     type: 'raw',
                     isMatch: ( node ) =>
                         node.nodeName === 'P' &&
-                        /^\s*\[alphalisting.*\]\s*$/.test( node.textContent ) &&
-                        canConvertShortcodeToBlock( node.textContent.trim() ),
+                        /^\s*\[alphalisting.*\]\s*$/.test( node.textContent ),
                     transform( node ) {
                         const attributes = parseShortcodeAttributes( node.textContent.trim() );
                         return createBlock( 'alphalisting/block', attributes );

--- a/scripts/blocks/index.js
+++ b/scripts/blocks/index.js
@@ -19,7 +19,7 @@ import Extensions from '../components/Extensions';
 import AZInspectorControls from '../components/AZInspectorControls';
 
 import shortcodeUpgrader from './shortcode-upgrader';
-import { parseShortcodeAttributes } from './shortcode-attributes';
+import { canConvertShortcodeToBlock, parseShortcodeAttributes } from './shortcode-attributes';
 
 const store = createReduxStore( 'alphalisting/slotfills', {
     reducer( state = {} ) {
@@ -110,7 +110,10 @@ domReady( () => {
                 },
                 {
                     type: 'raw',
-                    isMatch: ( node ) => node.nodeName === 'P' && /^\s*\[alphalisting.*\]\s*$/.test( node.textContent ),
+                    isMatch: ( node ) =>
+                        node.nodeName === 'P' &&
+                        /^\s*\[alphalisting.*\]\s*$/.test( node.textContent ) &&
+                        canConvertShortcodeToBlock( node.textContent.trim() ),
                     transform( node ) {
                         const attributes = parseShortcodeAttributes( node.textContent.trim() );
                         return createBlock( 'alphalisting/block', attributes );

--- a/scripts/blocks/shortcode-attributes.js
+++ b/scripts/blocks/shortcode-attributes.js
@@ -1,0 +1,87 @@
+import { attrs } from '@wordpress/shortcode';
+
+const BOOLEAN_ATTRIBUTES = new Set( [
+    'get-all-children',
+    'group-numbers',
+    'symbols-first',
+    'back-to-top',
+    'hide-empty',
+    'hide-empty-terms',
+] );
+
+const NUMBER_ATTRIBUTES = new Set( [ 'columns', 'grouping', 'parent-post' ] );
+
+const ARRAY_NUMBER_ATTRIBUTES = new Set( [ 'exclude-posts' ] );
+const ARRAY_STRING_ATTRIBUTES = new Set( [ 'terms', 'exclude-terms' ] );
+
+const isTruthy = ( value ) => {
+    if ( typeof value === 'boolean' ) {
+        return value;
+    }
+
+    if ( typeof value === 'number' ) {
+        return value !== 0;
+    }
+
+    if ( typeof value !== 'string' ) {
+        return false;
+    }
+
+    const normalized = value.trim().toLowerCase();
+
+    return [ '1', 'true', 'yes', 'y', 'on' ].includes( normalized );
+};
+
+const toArray = ( value ) => {
+    if ( Array.isArray( value ) ) {
+        return value;
+    }
+
+    if ( typeof value !== 'string' ) {
+        return [];
+    }
+
+    return value
+        .split( ',' )
+        .map( ( item ) => item.trim() )
+        .filter( Boolean );
+};
+
+const normalizeAttributeValue = ( key, value ) => {
+    if ( BOOLEAN_ATTRIBUTES.has( key ) ) {
+        return isTruthy( value );
+    }
+
+    if ( NUMBER_ATTRIBUTES.has( key ) ) {
+        const parsed = parseInt( value, 10 );
+
+        return Number.isNaN( parsed ) ? undefined : parsed;
+    }
+
+    if ( ARRAY_NUMBER_ATTRIBUTES.has( key ) ) {
+        return toArray( value )
+            .map( ( item ) => parseInt( item, 10 ) )
+            .filter( ( item ) => ! Number.isNaN( item ) );
+    }
+
+    if ( ARRAY_STRING_ATTRIBUTES.has( key ) ) {
+        return toArray( value );
+    }
+
+    return value;
+};
+
+export const parseShortcodeAttributes = ( shortcodeText ) => {
+    const parsedAttributes = attrs( shortcodeText );
+    const namedAttributes = parsedAttributes?.named || parsedAttributes || {};
+
+    return Object.entries( namedAttributes ).reduce( ( attributes, [ key, value ] ) => {
+        const normalizedValue = normalizeAttributeValue( key, value );
+
+        if ( typeof normalizedValue !== 'undefined' ) {
+            attributes[ key ] = normalizedValue;
+        }
+
+        return attributes;
+    }, {} );
+};

--- a/scripts/blocks/shortcode-attributes.js
+++ b/scripts/blocks/shortcode-attributes.js
@@ -13,9 +13,6 @@ const NUMBER_ATTRIBUTES = new Set( [ 'columns', 'grouping', 'parent-post' ] );
 
 const ARRAY_NUMBER_ATTRIBUTES = new Set( [ 'exclude-posts' ] );
 const ARRAY_STRING_ATTRIBUTES = new Set( [ 'terms', 'exclude-terms' ] );
-const SHORTCODE_DEFAULTS = {
-    'post-type': 'page',
-};
 
 const isTruthy = ( value ) => {
     if ( typeof value === 'boolean' ) {
@@ -52,9 +49,7 @@ const toArray = ( value ) => {
 
 const normalizeAttributeValue = ( key, value ) => {
     if ( key === 'post-type' ) {
-        const firstPostType = toArray( value )[ 0 ] ?? '';
-
-        return firstPostType || SHORTCODE_DEFAULTS['post-type'];
+        return typeof value === 'string' ? value.trim() : value;
     }
 
     if ( BOOLEAN_ATTRIBUTES.has( key ) ) {
@@ -84,9 +79,24 @@ const normalizeAttributeValue = ( key, value ) => {
     return value;
 };
 
-export const parseShortcodeAttributes = ( shortcodeText ) => {
+const getNamedShortcodeAttributes = ( shortcodeText ) => {
     const parsedAttributes = attrs( shortcodeText );
-    const namedAttributes = parsedAttributes?.named || parsedAttributes || {};
+    return parsedAttributes?.named || parsedAttributes || {};
+};
+
+export const canConvertShortcodeToBlock = ( shortcodeText ) => {
+    const namedAttributes = getNamedShortcodeAttributes( shortcodeText );
+    const postType = namedAttributes?.['post-type'];
+
+    if ( typeof postType !== 'string' ) {
+        return true;
+    }
+
+    return toArray( postType ).length <= 1;
+};
+
+export const parseShortcodeAttributes = ( shortcodeText ) => {
+    const namedAttributes = getNamedShortcodeAttributes( shortcodeText );
 
     const attributes = Object.entries( namedAttributes ).reduce( ( parsed, [ key, value ] ) => {
         const normalizedValue = normalizeAttributeValue( key, value );

--- a/scripts/blocks/shortcode-attributes.js
+++ b/scripts/blocks/shortcode-attributes.js
@@ -49,7 +49,9 @@ const toArray = ( value ) => {
 
 const normalizeAttributeValue = ( key, value ) => {
     if ( key === 'post-type' ) {
-        return toArray( value );
+        const postTypes = toArray( value );
+
+        return postTypes.length > 0 ? postTypes.join( ',' ) : undefined;
     }
 
     if ( BOOLEAN_ATTRIBUTES.has( key ) ) {

--- a/scripts/blocks/shortcode-attributes.js
+++ b/scripts/blocks/shortcode-attributes.js
@@ -49,7 +49,7 @@ const toArray = ( value ) => {
 
 const normalizeAttributeValue = ( key, value ) => {
     if ( key === 'post-type' ) {
-        return typeof value === 'string' ? value.trim() : value;
+        return toArray( value );
     }
 
     if ( BOOLEAN_ATTRIBUTES.has( key ) ) {
@@ -82,17 +82,6 @@ const normalizeAttributeValue = ( key, value ) => {
 const getNamedShortcodeAttributes = ( shortcodeText ) => {
     const parsedAttributes = attrs( shortcodeText );
     return parsedAttributes?.named || parsedAttributes || {};
-};
-
-export const canConvertShortcodeToBlock = ( shortcodeText ) => {
-    const namedAttributes = getNamedShortcodeAttributes( shortcodeText );
-    const postType = namedAttributes?.['post-type'];
-
-    if ( typeof postType !== 'string' ) {
-        return true;
-    }
-
-    return toArray( postType ).length <= 1;
 };
 
 export const parseShortcodeAttributes = ( shortcodeText ) => {

--- a/scripts/blocks/shortcode-attributes.js
+++ b/scripts/blocks/shortcode-attributes.js
@@ -13,6 +13,9 @@ const NUMBER_ATTRIBUTES = new Set( [ 'columns', 'grouping', 'parent-post' ] );
 
 const ARRAY_NUMBER_ATTRIBUTES = new Set( [ 'exclude-posts' ] );
 const ARRAY_STRING_ATTRIBUTES = new Set( [ 'terms', 'exclude-terms' ] );
+const SHORTCODE_DEFAULTS = {
+    'post-type': 'page',
+};
 
 const isTruthy = ( value ) => {
     if ( typeof value === 'boolean' ) {
@@ -48,13 +51,19 @@ const toArray = ( value ) => {
 };
 
 const normalizeAttributeValue = ( key, value ) => {
+    if ( key === 'post-type' ) {
+        const firstPostType = toArray( value )[ 0 ] ?? '';
+
+        return firstPostType || SHORTCODE_DEFAULTS['post-type'];
+    }
+
     if ( BOOLEAN_ATTRIBUTES.has( key ) ) {
         return isTruthy( value );
     }
 
     if ( NUMBER_ATTRIBUTES.has( key ) ) {
         if ( key === 'grouping' && typeof value === 'string' && value.trim().toLowerCase() === 'numbers' ) {
-            return 0;
+            return undefined;
         }
 
         const parsed = parseInt( value, 10 );

--- a/scripts/blocks/shortcode-attributes.js
+++ b/scripts/blocks/shortcode-attributes.js
@@ -53,6 +53,10 @@ const normalizeAttributeValue = ( key, value ) => {
     }
 
     if ( NUMBER_ATTRIBUTES.has( key ) ) {
+        if ( key === 'grouping' && typeof value === 'string' && value.trim().toLowerCase() === 'numbers' ) {
+            return 0;
+        }
+
         const parsed = parseInt( value, 10 );
 
         return Number.isNaN( parsed ) ? undefined : parsed;
@@ -75,13 +79,19 @@ export const parseShortcodeAttributes = ( shortcodeText ) => {
     const parsedAttributes = attrs( shortcodeText );
     const namedAttributes = parsedAttributes?.named || parsedAttributes || {};
 
-    return Object.entries( namedAttributes ).reduce( ( attributes, [ key, value ] ) => {
+    const attributes = Object.entries( namedAttributes ).reduce( ( parsed, [ key, value ] ) => {
         const normalizedValue = normalizeAttributeValue( key, value );
 
         if ( typeof normalizedValue !== 'undefined' ) {
-            attributes[ key ] = normalizedValue;
+            parsed[ key ] = normalizedValue;
         }
 
-        return attributes;
+        return parsed;
     }, {} );
+
+    if ( typeof namedAttributes.grouping === 'string' && namedAttributes.grouping.trim().toLowerCase() === 'numbers' ) {
+        attributes[ 'group-numbers' ] = true;
+    }
+
+    return attributes;
 };

--- a/scripts/blocks/shortcode-upgrader.js
+++ b/scripts/blocks/shortcode-upgrader.js
@@ -1,7 +1,7 @@
 import { createBlock } from '@wordpress/blocks';
 import { subscribe, select, dispatch } from '@wordpress/data';
 
-import { canConvertShortcodeToBlock, parseShortcodeAttributes } from './shortcode-attributes';
+import { parseShortcodeAttributes } from './shortcode-attributes';
 
 const validBlocks = ( blocks ) => Array.isArray( blocks ) && blocks.length > 0;
 
@@ -14,8 +14,7 @@ const transform = ( block ) => {
     if (
         block.name === 'core/shortcode' &&
         typeof block.attributes.text === 'string' &&
-        block.attributes.text.startsWith( '[alphalisting' ) &&
-        canConvertShortcodeToBlock( block.attributes.text )
+        block.attributes.text.startsWith( '[alphalisting' )
     ) {
         dispatch( 'core/block-editor' ).replaceBlocks( [ block.clientId ], [ blockHandler( block ) ] );
         return;

--- a/scripts/blocks/shortcode-upgrader.js
+++ b/scripts/blocks/shortcode-upgrader.js
@@ -1,7 +1,7 @@
 import { createBlock } from '@wordpress/blocks';
 import { subscribe, select, dispatch } from '@wordpress/data';
 
-import { parseShortcodeAttributes } from './shortcode-attributes';
+import { canConvertShortcodeToBlock, parseShortcodeAttributes } from './shortcode-attributes';
 
 const validBlocks = ( blocks ) => Array.isArray( blocks ) && blocks.length > 0;
 
@@ -14,7 +14,8 @@ const transform = ( block ) => {
     if (
         block.name === 'core/shortcode' &&
         typeof block.attributes.text === 'string' &&
-        block.attributes.text.startsWith( '[alphalisting' )
+        block.attributes.text.startsWith( '[alphalisting' ) &&
+        canConvertShortcodeToBlock( block.attributes.text )
     ) {
         dispatch( 'core/block-editor' ).replaceBlocks( [ block.clientId ], [ blockHandler( block ) ] );
         return;

--- a/scripts/blocks/shortcode-upgrader.js
+++ b/scripts/blocks/shortcode-upgrader.js
@@ -1,41 +1,44 @@
 import { createBlock } from '@wordpress/blocks';
 import { subscribe, select, dispatch } from '@wordpress/data';
-import { attrs } from '@wordpress/shortcode';
 
-const validBlocks = ( blocks ) => blocks && blocks.length > 0;
+import { parseShortcodeAttributes } from './shortcode-attributes';
+
+const validBlocks = ( blocks ) => Array.isArray( blocks ) && blocks.length > 0;
 
 const blockHandler = ( block ) => {
-	const atts = attrs( block.attributes.text )
-	return createBlock( 'alphalisting/block', atts );
-}
+    const attributes = parseShortcodeAttributes( block.attributes.text );
+    return createBlock( 'alphalisting/block', attributes );
+};
 
 const transform = ( block ) => {
-	if ( block.name === 'core/shortcode' && block.attributes.text.startsWith( '[alphalisting' ) ) {
-		dispatch('core/block-editor')
-			.replaceBlocks( [ block.clientId ], [ blockHandler( block ) ] );
-	} else if ( validBlocks( block.innerBlocks ) ) {
-		convertBlocks( block.innerBlocks );
-	}
-}
+    if (
+        block.name === 'core/shortcode' &&
+        typeof block.attributes.text === 'string' &&
+        block.attributes.text.startsWith( '[alphalisting' )
+    ) {
+        dispatch( 'core/block-editor' ).replaceBlocks( [ block.clientId ], [ blockHandler( block ) ] );
+        return;
+    }
 
-const convertBlocks = ( blocks, depth = 1, maxDepth = 3 ) => {
-	for ( const block of blocks) {
-		const innerBlocks = { block };
-		transform( block );
-		if (depth <= maxDepth && validBlocks( innerBlocks ) ) {
-			convertBlocks( innerBlocks, depth + 1, maxDepth );
-		}
-	}
-}
+    if ( validBlocks( block.innerBlocks ) ) {
+        convertBlocks( block.innerBlocks );
+    }
+};
+
+const convertBlocks = ( blocks ) => {
+    for ( const block of blocks ) {
+        transform( block );
+    }
+};
 
 export default () => {
-	const unsubscribe = subscribe( () => {
-		const coreEditor = select( 'core/block-editor' );
-		const blocks = coreEditor.getBlocks();
+    const unsubscribe = subscribe( () => {
+        const coreEditor = select( 'core/block-editor' );
+        const blocks = coreEditor.getBlocks();
 
-		if ( validBlocks( blocks ) ) {
-			unsubscribe();
-			convertBlocks( blocks, 1, 3 );
-		}
-	} )
-}
+        if ( validBlocks( blocks ) ) {
+            unsubscribe();
+            convertBlocks( blocks );
+        }
+    } );
+};

--- a/src/Shortcode/QueryParts/PostType.php
+++ b/src/Shortcode/QueryParts/PostType.php
@@ -47,12 +47,21 @@ class PostType extends Extension {
 	/**
 	 * Sanitize the shortcode attribute.
 	 *
-	 * @param string $value      The value of the shortcode attribute.
+	 * @param mixed $value      The value of the shortcode attribute.
 	 * @param array  $attributes The complete set of shortcode attributes.
 	 * @return string The sanitized value.
 	 */
 	public function sanitize_attribute( $value, array $attributes ) {
-		$value = trim( $value );
+		if ( is_array( $value ) ) {
+			$value = array_map( 'strval', $value );
+			$value = array_map( 'trim', $value );
+			$value = array_filter( $value );
+			$value = array_unique( $value );
+			$value = implode( ',', $value );
+		} else {
+			$value = trim( strval( $value ) );
+		}
+
 		return $value ? $value : 'page';
 	}
 


### PR DESCRIPTION
### Motivation
- Shortcodes like `[alphalisting display="posts" post-type="post"]` were converted to the AlphaListing block but lost or mis-typed attributes during upgrade. 
- The core issue was that raw shortcode parser output was passed directly to block creation without normalizing values to the block schema types. 
- The change ensures converted blocks receive correctly-typed attributes and preserves previous shortcode behavior.

### Description
- Added a dedicated parser `scripts/blocks/shortcode-attributes.js` that extracts named shortcode attributes and normalizes booleans, numbers, and comma-separated arrays. 
- Updated the raw transform in `scripts/blocks/index.js` to use `parseShortcodeAttributes(...)` when creating `alphalisting/block` so pasted shortcodes map to block attributes. 
- Refactored `scripts/blocks/shortcode-upgrader.js` to use the shared parser and added safer guards and simpler recursive conversion logic for converting `core/shortcode` blocks. 
- Built assets so the block bundle uses the updated parser (`npm run build`).

### Testing
- Ran `npm run build` and the build completed successfully. 
- No automated unit tests exist in the project; changes were validated by building the block assets to ensure no compile failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d6734d3de4832180d0a549644dab24)