### PR TITLE
fix(block): preserve shortcode attributes during block conversion

### DIFF
--- a/scripts/blocks/index.js
+++ b/scripts/blocks/index.js
@@ -21,6 +21,26 @@ import AZInspectorControls from '../components/AZInspectorControls';
 import shortcodeUpgrader from './shortcode-upgrader';
 import { parseShortcodeAttributes } from './shortcode-attributes';
 
+const createBlockFromShortcodeText = ( shortcodeText ) => {
+    if ( typeof shortcodeText !== 'string' ) {
+        return createBlock( 'alphalisting/block' );
+    }
+
+    let normalizedShortcode = shortcodeText.trim();
+
+    if ( ! normalizedShortcode.startsWith( '[alphalisting' ) ) {
+        normalizedShortcode = `[alphalisting${normalizedShortcode}`;
+    }
+
+    if ( ! normalizedShortcode.endsWith( ']' ) ) {
+        normalizedShortcode = `${normalizedShortcode}]`;
+    }
+
+    const attributes = parseShortcodeAttributes( normalizedShortcode );
+
+    return createBlock( 'alphalisting/block', attributes );
+};
+
 const store = createReduxStore( 'alphalisting/slotfills', {
     reducer( state = {} ) {
         return state;
@@ -99,15 +119,15 @@ domReady( () => {
                 {
                     type: 'prefix',
                     prefix: '[alphalisting',
-                    transform() {
-                        return createBlock( 'alphalisting/block' );
+                    transform( content ) {
+                        return createBlockFromShortcodeText( content );
                     },
                 },
                 {
                     type: 'prefix',
                     prefix: '[alphalisting]',
-                    transform() {
-                        return createBlock( 'alphalisting/block' );
+                    transform( content ) {
+                        return createBlockFromShortcodeText( content );
                     },
                 },
                 {
@@ -116,8 +136,7 @@ domReady( () => {
                         node.nodeName === 'P' &&
                         /^\s*\[alphalisting.*\]\s*$/.test( node.textContent ),
                     transform( node ) {
-                        const attributes = parseShortcodeAttributes( node.textContent.trim() );
-                        return createBlock( 'alphalisting/block', attributes );
+                        return createBlockFromShortcodeText( node.textContent );
                     },
                 },
             ],

--- a/scripts/blocks/index.js
+++ b/scripts/blocks/index.js
@@ -41,6 +41,17 @@ const createBlockFromShortcodeText = ( shortcodeText ) => {
     return createBlock( 'alphalisting/block', attributes );
 };
 
+const createBlockFromPrefixContent = ( prefixContent ) => {
+    if ( typeof prefixContent !== 'string' ) {
+        return createBlock( 'alphalisting/block' );
+    }
+
+    const shouldInsertSpace = prefixContent !== '' && ! /^[\s\]]/.test( prefixContent );
+    const normalizedShortcode = `[alphalisting${shouldInsertSpace ? ' ' : ''}${prefixContent}`;
+
+    return createBlockFromShortcodeText( normalizedShortcode );
+};
+
 const store = createReduxStore( 'alphalisting/slotfills', {
     reducer( state = {} ) {
         return state;
@@ -120,14 +131,14 @@ domReady( () => {
                     type: 'prefix',
                     prefix: '[alphalisting',
                     transform( content ) {
-                        return createBlockFromShortcodeText( content );
+                        return createBlockFromPrefixContent( content );
                     },
                 },
                 {
                     type: 'prefix',
                     prefix: '[alphalisting]',
                     transform( content ) {
-                        return createBlockFromShortcodeText( content );
+                        return createBlockFromPrefixContent( content );
                     },
                 },
                 {

--- a/scripts/blocks/shortcode-upgrader.js
+++ b/scripts/blocks/shortcode-upgrader.js
@@ -5,16 +5,19 @@ import { parseShortcodeAttributes } from './shortcode-attributes';
 
 const validBlocks = ( blocks ) => Array.isArray( blocks ) && blocks.length > 0;
 
+const isAlphaListingShortcode = ( shortcodeText ) => {
+    return typeof shortcodeText === 'string' && /^\s*\[alphalisting(?:\s|\]|$)/.test( shortcodeText );
+};
+
 const blockHandler = ( block ) => {
-    const attributes = parseShortcodeAttributes( block.attributes.text );
+    const attributes = parseShortcodeAttributes( block.attributes.text.trim() );
     return createBlock( 'alphalisting/block', attributes );
 };
 
 const transform = ( block ) => {
     if (
         block.name === 'core/shortcode' &&
-        typeof block.attributes.text === 'string' &&
-        block.attributes.text.startsWith( '[alphalisting' )
+        isAlphaListingShortcode( block.attributes.text )
     ) {
         dispatch( 'core/block-editor' ).replaceBlocks( [ block.clientId ], [ blockHandler( block ) ] );
         return;


### PR DESCRIPTION
### Motivation
- Converting `[alphalisting ...]` shortcodes to the AlphaListing block could drop provided shortcode attributes (e.g. `back-to-top="false"`) because some conversion paths created a block with defaults instead of parsing attributes.
- Make all conversion paths consistent so user-provided shortcode arguments are always preserved when producing a block.

### Description
- Added a helper `createBlockFromShortcodeText` in `scripts/blocks/index.js` to normalize shortcode text, parse attributes with `parseShortcodeAttributes`, and create the block using the parsed attributes.
- Updated the prefix transforms (`[alphalisting` and `[alphalisting]`) and the raw transform in `scripts/blocks/index.js` to use the new helper so parsed attributes are applied during conversion.
- Hardened the upgrader in `scripts/blocks/shortcode-upgrader.js` by adding `isAlphaListingShortcode` (accepts leading whitespace) and trimming `block.attributes.text` before parsing to ensure reliable conversion from `core/shortcode` blocks.
- No public shortcode arguments or block attribute names were changed; this centralizes and preserves existing behavior.

### Testing
- Ran `npm run build` which completed successfully and produced the updated block assets.
- Ran `npm run lint:js` which failed due to many pre-existing repository lint issues unrelated to this change (unresolved WP module imports and legacy script style violations).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d6bd96b4e88321b93b3d9466a9f4ed)