### PR TITLE
shortcode(exclude-terms): safely merge tax_query clauses

### DIFF
--- a/src/Shortcode/QueryParts/ExcludeTerms.php
+++ b/src/Shortcode/QueryParts/ExcludeTerms.php
@@ -81,29 +81,20 @@ class ExcludeTerms extends Extension {
             "operator" => "NOT IN",
         ];
 
-        $existing_tax_query = isset($query["tax_query"]) && is_array($query["tax_query"])
+        $tax_query = isset($query["tax_query"]) && is_array($query["tax_query"])
             ? $query["tax_query"]
             : [];
 
-        $relation = null;
-        if (isset($existing_tax_query["relation"])) {
-            $existing_relation = strtoupper((string) $existing_tax_query["relation"]);
+        if (isset($tax_query["relation"])) {
+            $existing_relation = strtoupper((string) $tax_query["relation"]);
             if (in_array($existing_relation, ["AND", "OR"], true)) {
-                $relation = $existing_relation;
-            }
-        }
-
-        $tax_query = [];
-        foreach ($existing_tax_query as $index => $clause) {
-            if (is_int($index) && is_array($clause)) {
-                $tax_query[] = $clause;
+                $tax_query["relation"] = $existing_relation;
+            } else {
+                unset($tax_query["relation"]);
             }
         }
 
         $tax_query[] = $exclude_clause;
-        if (null !== $relation) {
-            $tax_query["relation"] = $relation;
-        }
 
         $query["tax_query"] = $tax_query; // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
         return $query;

--- a/src/Shortcode/QueryParts/ExcludeTerms.php
+++ b/src/Shortcode/QueryParts/ExcludeTerms.php
@@ -74,23 +74,38 @@ class ExcludeTerms extends Extension {
             ? $attributes["taxonomy"]
             : "category";
 
-        $tax_query = [
-            [
-                "taxonomy" => $taxonomy,
-                "field" => "term_id",
-                "terms" => $exclude_terms,
-                "operator" => "NOT IN",
-            ],
+        $exclude_clause = [
+            "taxonomy" => $taxonomy,
+            "field" => "term_id",
+            "terms" => $exclude_terms,
+            "operator" => "NOT IN",
         ];
 
-        if (isset($query["tax_query"])) {
-            $query["tax_query"] = wp_parse_args(
-                $query["tax_query"],
-                $tax_query,
-            ); // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
-        } else {
-            $query["tax_query"] = $tax_query; // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
+        $existing_tax_query = isset($query["tax_query"]) && is_array($query["tax_query"])
+            ? $query["tax_query"]
+            : [];
+
+        $relation = null;
+        if (isset($existing_tax_query["relation"])) {
+            $existing_relation = strtoupper((string) $existing_tax_query["relation"]);
+            if (in_array($existing_relation, ["AND", "OR"], true)) {
+                $relation = $existing_relation;
+            }
         }
+
+        $tax_query = [];
+        foreach ($existing_tax_query as $index => $clause) {
+            if (is_int($index) && is_array($clause)) {
+                $tax_query[] = $clause;
+            }
+        }
+
+        $tax_query[] = $exclude_clause;
+        if (null !== $relation) {
+            $tax_query["relation"] = $relation;
+        }
+
+        $query["tax_query"] = $tax_query; // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
         return $query;
     }
 

--- a/test/exclude-terms-tax-query-merge.php
+++ b/test/exclude-terms-tax-query-merge.php
@@ -99,4 +99,30 @@ if (($query_with_relation["tax_query"][1]["operator"] ?? null) !== "NOT IN") {
     throw new RuntimeException("Expected appended clause operator to be NOT IN for relation tax_query.");
 }
 
-echo "ExcludeTerms merges tax_query clauses correctly for absent, numeric, and relation scenarios.\n";
+$query_with_named_clause = alphalisting_build_posts_query_with_exclude_terms(
+    [
+        "tax_query" => [
+            "relation" => "AND",
+            "featured_terms" => [
+                "taxonomy" => "category",
+                "field" => "slug",
+                "terms" => ["featured"],
+                "operator" => "IN",
+            ],
+        ],
+    ],
+);
+
+if (($query_with_named_clause["tax_query"]["relation"] ?? null) !== "AND") {
+    throw new RuntimeException("Expected relation to be preserved for named tax_query clauses.");
+}
+
+if (!isset($query_with_named_clause["tax_query"]["featured_terms"])) {
+    throw new RuntimeException("Expected named tax_query clause to be preserved.");
+}
+
+if (($query_with_named_clause["tax_query"][0]["operator"] ?? null) !== "NOT IN") {
+    throw new RuntimeException("Expected NOT IN clause to append without removing named clauses.");
+}
+
+echo "ExcludeTerms merges tax_query clauses correctly for absent, numeric, relation, and named-clause scenarios.\n";

--- a/test/exclude-terms-tax-query-merge.php
+++ b/test/exclude-terms-tax-query-merge.php
@@ -1,0 +1,102 @@
+<?php
+declare(strict_types=1);
+
+if (!defined("ABSPATH")) {
+    define("ABSPATH", __DIR__);
+}
+
+require_once __DIR__ . '/../src/Extension.php';
+require_once __DIR__ . '/../src/Singleton.php';
+require_once __DIR__ . '/../src/Strings.php';
+require_once __DIR__ . '/../src/Shortcode/Extension.php';
+require_once __DIR__ . '/../src/Shortcode/QueryParts/ExcludeTerms.php';
+
+use eslin87\AlphaListing\Shortcode\QueryParts\ExcludeTerms;
+
+$extension = new ExcludeTerms();
+
+$attributes = [
+    "taxonomy" => "category",
+];
+
+/**
+ * Build a posts query through the exclude-terms query part.
+ *
+ * @param array $query The starting query args.
+ * @return array
+ */
+function alphalisting_build_posts_query_with_exclude_terms(array $query): array {
+    global $extension;
+    global $attributes;
+
+    return $extension->shortcode_query_for_display_and_attribute(
+        $query,
+        "posts",
+        "exclude-terms",
+        "10,11",
+        $attributes,
+    );
+}
+
+$query_without_tax_query = alphalisting_build_posts_query_with_exclude_terms([]);
+
+if (!isset($query_without_tax_query["tax_query"][0])) {
+    throw new RuntimeException("Expected a new tax_query clause when tax_query is absent.");
+}
+
+if (isset($query_without_tax_query["tax_query"]["relation"])) {
+    throw new RuntimeException("Did not expect a relation key when none existed previously.");
+}
+
+$existing_numeric_clause = [
+    [
+        "taxonomy" => "post_tag",
+        "field" => "term_id",
+        "terms" => [33],
+        "operator" => "IN",
+    ],
+];
+
+$query_with_numeric_tax_query = alphalisting_build_posts_query_with_exclude_terms(
+    ["tax_query" => $existing_numeric_clause],
+);
+
+if (count($query_with_numeric_tax_query["tax_query"]) !== 2) {
+    throw new RuntimeException("Expected numeric tax_query clauses to be preserved and appended.");
+}
+
+if ($query_with_numeric_tax_query["tax_query"][0] !== $existing_numeric_clause[0]) {
+    throw new RuntimeException("Expected existing numeric clause to remain unchanged.");
+}
+
+if (($query_with_numeric_tax_query["tax_query"][1]["operator"] ?? null) !== "NOT IN") {
+    throw new RuntimeException("Expected appended clause to use NOT IN operator.");
+}
+
+$query_with_relation = alphalisting_build_posts_query_with_exclude_terms(
+    [
+        "tax_query" => [
+            "relation" => "OR",
+            [
+                "taxonomy" => "category",
+                "field" => "term_id",
+                "terms" => [99],
+                "operator" => "IN",
+            ],
+        ],
+    ],
+);
+
+if (($query_with_relation["tax_query"]["relation"] ?? null) !== "OR") {
+    throw new RuntimeException("Expected existing tax_query relation to be preserved.");
+}
+
+if (!isset($query_with_relation["tax_query"][1])) {
+    throw new RuntimeException("Expected appended clause when tax_query contains a relation key.");
+}
+
+if (($query_with_relation["tax_query"][1]["operator"] ?? null) !== "NOT IN") {
+    throw new RuntimeException("Expected appended clause operator to be NOT IN for relation tax_query.");
+}
+
+echo "ExcludeTerms merges tax_query clauses correctly for absent, numeric, and relation scenarios.\n";


### PR DESCRIPTION
### Motivation
- `wp_parse_args()` was being used to merge a new `tax_query` clause which can mis-handle numeric clause arrays and relation keys, producing incorrect combined `tax_query` structures. 
- The goal is to ensure the `exclude-terms` shortcode appends a `NOT IN` clause while preserving any existing numeric clauses and any valid `relation` (`AND`/`OR`).

### Description
- Replaced `wp_parse_args( $query['tax_query'], $tax_query )` with explicit merge logic that builds an `exclude_clause` and appends it to preserved numeric clauses. 
- Detects and preserves an existing `tax_query['relation']` when it is `AND` or `OR` and places it on the resulting `tax_query`. 
- Handles cases where `tax_query` is absent, a numeric array of clauses, or an array containing a `relation` key to ensure consistent behavior. 
- Added a verification script `test/exclude-terms-tax-query-merge.php` that asserts correct behavior for the three scenarios requested.

### Testing
- Ran `php -l src/Shortcode/QueryParts/ExcludeTerms.php` and `php -l test/exclude-terms-tax-query-merge.php` with no syntax errors. 
- Executed the new test script with `php test/exclude-terms-tax-query-merge.php` which printed a success message indicating the absent, numeric, and relation scenarios passed. 
- All automated checks executed locally passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d7b5444d4c8321808b5f54d9f3e089)