### PR TITLE
Add "Group by last word" option for post listings

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ This plugin includes a block and shortcode for the list, along with a widget for
 
 Show posts from any single or multiple post types, including built-in posts and pages. Post types from plugins like WooCommerce products are also supported. Alternatively, display terms such as categories or tags.
 
+Post listings can be grouped and sorted by the last word of each post title. Enable "Group by last word" in the block settings, or add `group-by="last-word"` to the shortcode. The complete post title remains visible in the listing.
+
 _This plugin is based on the original **A-Z Listing** by Lucy (formerly Dani) Llewellyn, which is no longer maintained. Custom templates built for the original plugin may not work reliably with this version. For the most up-to-date example template, see the [example template](https://raw.githubusercontent.com/Lin87/alphalisting/refs/heads/main/templates/a-z-listing.example.php)._
 
 ## Installation ##

--- a/alphalisting.php
+++ b/alphalisting.php
@@ -64,6 +64,7 @@ function alphalisting_init() {
 	\eslin87\AlphaListing\Shortcode\QueryParts\ColumnWidth::instance()->activate( __FILE__ )->initialize();
 	\eslin87\AlphaListing\Shortcode\QueryParts\ExcludePosts::instance()->activate( __FILE__ )->initialize();
 	\eslin87\AlphaListing\Shortcode\QueryParts\ExcludeTerms::instance()->activate( __FILE__ )->initialize();
+    \eslin87\AlphaListing\Shortcode\QueryParts\GroupBy::instance()->activate( __FILE__ )->initialize();
 	\eslin87\AlphaListing\Shortcode\QueryParts\HideEmpty_Deprecated::instance()->activate( __FILE__ )->initialize();
 	\eslin87\AlphaListing\Shortcode\QueryParts\HideEmptyTerms::instance()->activate( __FILE__ )->initialize();
 	\eslin87\AlphaListing\Shortcode\QueryParts\InstanceId::instance()->activate( __FILE__ )->initialize();

--- a/languages/alphalisting.pot
+++ b/languages/alphalisting.pot
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: AlphaListing 4.4.0\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/alphalisting\n"
-"POT-Creation-Date: 2026-05-28 19:26:54+00:00\n"
+"POT-Creation-Date: 2026-08-13 14:03:09+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -83,6 +83,14 @@ msgstr ""
 #. to 9), or some other character that is not a standard English alphabet
 #. letter.
 msgid "#"
+msgstr ""
+
+#: scripts/blocks/edit.js:699
+msgid "Group by last word"
+msgstr ""
+
+#: scripts/blocks/edit.js:706
+msgid "Group and sort posts by the last word of their title."
 msgstr ""
 
 #: templates/a-z-listing.example.php:52 templates/a-z-listing.php:76

--- a/readme.txt
+++ b/readme.txt
@@ -19,6 +19,8 @@ This plugin includes a block and shortcode for the list, along with a widget for
 
 Show posts from any single or multiple post types, including built-in posts and pages. Post types from plugins like WooCommerce products are also supported. Alternatively, display terms such as categories or tags.
 
+Post listings can be grouped and sorted by the last word of each post title. Enable "Group by last word" in the block settings, or add `group-by="last-word"` to the shortcode. The complete post title remains visible in the listing.
+
 _This plugin is based on the original **A-Z Listing** by Lucy (formerly Dani) Llewellyn, which is no longer maintained. Custom templates built for the original plugin may not work reliably with this version. For the most up-to-date example template, see the [example template](https://raw.githubusercontent.com/Lin87/alphalisting/refs/heads/main/templates/a-z-listing.example.php)._
 
 == Installation ==

--- a/scripts/blocks/attributes.json
+++ b/scripts/blocks/attributes.json
@@ -35,6 +35,11 @@
         "type": "number",
         "default": 1
     },
+    "group-by": {
+        "type": "string",
+        "enum": ["", "last-word"],
+        "default": ""
+    },
     "instance-id": {
         "type": "string"
     },

--- a/scripts/blocks/edit.js
+++ b/scripts/blocks/edit.js
@@ -694,6 +694,20 @@ const A_Z_Listing_Edit = ( { attributes, setAttributes } ) => {
 											__next40pxDefaultSize
 											__nextHasNoMarginBottom
 										/>
+                                        { 'posts' === attributes.display && (
+                                            <ToggleControl
+                                                label={ __( 'Group by last word', 'alphalisting' ) }
+                                                checked={ 'last-word' === attributes['group-by'] }
+                                                onChange={ ( enabled ) =>
+                                                    setAttributes( {
+                                                        'group-by': enabled ? 'last-word' : '',
+                                                    } )
+                                                }
+                                                help={ __( 'Group and sort posts by the last word of their title.', 'alphalisting' ) }
+                                                __next40pxDefaultSize
+                                                __nextHasNoMarginBottom
+                                            />
+                                        ) }
 										<SelectControl
 											label={ __( 'Numbers', 'alphalisting' ) }
 											value={ attributes.numbers ?? defaults['numbers'].default }

--- a/src/Alphabet.php
+++ b/src/Alphabet.php
@@ -203,6 +203,58 @@ class Alphabet {
 		return $this->unknown_letter;
 	}
 
+    /**
+     * Compare strings using the configured alphabet order and character groups.
+     *
+     * @param string $first  The first string.
+     * @param string $second The second string.
+     * @return int -1, 0, or 1 according to the configured alphabet.
+     */
+    public function compare_strings( string $first, string $second ): int {
+        $first_characters  = $this->normalize_string_for_sorting( $first );
+        $second_characters = $this->normalize_string_for_sorting( $second );
+        $minimum_length    = min( count( $first_characters ), count( $second_characters ) );
+
+        for ( $index = 0; $index < $minimum_length; ++$index ) {
+            $first_position  = array_search( $first_characters[ $index ], $this->alphabet_keys, true );
+            $second_position = array_search( $second_characters[ $index ], $this->alphabet_keys, true );
+            $first_unknown   = ! is_int( $first_position );
+            $second_unknown  = ! is_int( $second_position );
+
+            if ( $first_unknown && ! $second_unknown ) {
+                return $this->unknown_letter_is_first ? -1 : 1;
+            }
+            if ( ! $first_unknown && $second_unknown ) {
+                return $this->unknown_letter_is_first ? 1 : -1;
+            }
+
+            $comparison = $first_unknown
+                ? $first_characters[ $index ] <=> $second_characters[ $index ]
+                : $first_position <=> $second_position;
+            if ( 0 !== $comparison ) {
+                return $comparison;
+            }
+        }
+
+        return count( $first_characters ) <=> count( $second_characters );
+    }
+
+    /**
+     * Normalize a string to the representative characters in the alphabet.
+     *
+     * @param string $value The string to normalize.
+     * @return array<int,string>
+     */
+    private function normalize_string_for_sorting( string $value ): array {
+        return array_map(
+            function( string $character ): string {
+                $normalized = $this->get_letter_for_key( $character );
+                return $normalized === $this->unknown_letter ? $character : $normalized;
+            },
+            Strings::mb_string_to_array( $value )
+        );
+    }
+
 	/**
 	 * Get the alphabet characters.
 	 *

--- a/src/Indices.php
+++ b/src/Indices.php
@@ -123,7 +123,12 @@ class Indices extends Singleton implements Extension {
 		 * @param string $title The filtered title used to index the item.
 		 */
 		$index_letters = apply_filters( 'alphalisting_item_index_letter', $index_letters, $item, $type, $title );
-		$index_letters = array_unique( array_filter( $index_letters ) );
+        $index_letters = array_unique(
+            array_filter(
+                $index_letters,
+                static fn( $letter ): bool => '' !== (string) $letter
+            )
+        );
 
 		foreach ( $index_letters as $letter ) {
 			$indices[ $alphabet->get_letter_for_key( $letter ) ][] = array(

--- a/src/Indices.php
+++ b/src/Indices.php
@@ -108,8 +108,9 @@ class Indices extends Singleton implements Extension {
 		 * @param array  $indices The current indices
 		 * @param mixed  $item The item
 		 * @param string $item_type The type of the listing.
+		 * @param string $title The filtered title used to index the item.
 		 */
-		$index_letters = apply_filters( 'alphalisting-item-index-letter', array( $index ), $item, $type ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
+		$index_letters = apply_filters( 'alphalisting-item-index-letter', array( $index ), $item, $type, $title ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
 
 		/**
 		 * Modify the index/indices to group this item under
@@ -119,8 +120,9 @@ class Indices extends Singleton implements Extension {
 		 * @param array  $indices The current indices
 		 * @param mixed  $item The item
 		 * @param string $item_type The type of the listing.
+		 * @param string $title The filtered title used to index the item.
 		 */
-		$index_letters = apply_filters( 'alphalisting_item_index_letter', $index_letters, $item, $type );
+		$index_letters = apply_filters( 'alphalisting_item_index_letter', $index_letters, $item, $type, $title );
 		$index_letters = array_unique( array_filter( $index_letters ) );
 
 		foreach ( $index_letters as $letter ) {

--- a/src/Query.php
+++ b/src/Query.php
@@ -486,68 +486,7 @@ class Query {
 							$atitle = strtolower( $a['title'] );
 							$btitle = strtolower( $b['title'] );
 
-							$atitle_array = Strings::mb_string_to_array( $atitle );
-							$btitle_array = Strings::mb_string_to_array( $btitle );
-
-							$atitle_array = array_map(
-								function( $letter ) use ( $alphabet ) {
-									$normalized_letter = $alphabet->get_letter_for_key( $letter );
-									if ( $normalized_letter === $alphabet->unknown_letter ) {
-										$normalized_letter = $letter;
-									}
-									return $normalized_letter;
-								},
-								$atitle_array
-							);
-							$btitle_array = array_map(
-								function( $letter ) use ( $alphabet ) {
-									$normalized_letter = $alphabet->get_letter_for_key( $letter );
-									if ( $normalized_letter === $alphabet->unknown_letter ) {
-										$normalized_letter = $letter;
-									}
-									return $normalized_letter;
-								},
-								$btitle_array
-							);
-
-							$default_sort = 0;
-							if ( implode( '', $atitle_array ) != implode( '', $btitle_array ) ) {
-								$min_length = min( count( $atitle_array ), count( $btitle_array ) );
-								for ( $idx = 0; $idx < $min_length; ++$idx ) {
-									$a_has_symbol = false;
-									$b_has_symbol = false;
-
-									$aletter = array_search( $atitle_array[ $idx ], $alphabet->alphabet_keys );
-									$bletter = array_search( $btitle_array[ $idx ], $alphabet->alphabet_keys );
-
-									if ( ! is_int( $aletter ) ) {
-										$aletter = $atitle_array[ $idx ];
-										$a_has_symbol = true;
-									}
-									if ( ! is_int( $bletter ) ) {
-										$bletter = $btitle_array[ $idx ];
-										$b_has_symbol = true;
-									}
-
-									if ( $a_has_symbol && ! $b_has_symbol ) {
-										$default_sort = $alphabet->unknown_letter_is_first ? -1 : 1;
-									} elseif ( ! $a_has_symbol && $b_has_symbol ) {
-										$default_sort = $alphabet->unknown_letter_is_first ? 1 : -1;
-									} elseif ( $a_has_symbol && $b_has_symbol ) {
-										$default_sort = $aletter <=> $bletter;
-									} else {
-										$default_sort = $aletter <=> $bletter;
-									}
-
-									if ( 0 !== $default_sort ) {
-										break;
-									}
-								}
-
-								if ( 0 === $default_sort ) {
-									$default_sort = count( $atitle_array ) <=> count( $btitle_array );
-								}
-							}
+                            $default_sort = $alphabet->compare_strings( $atitle, $btitle );
 
 							/**
 							 * Compare two titles to determine sorting order.
@@ -556,13 +495,15 @@ class Query {
 							 * @param int The previous order preference: -1 if $a is less than $b. 1 if $a is greater than $b. 0 if they are identical.
 							 * @param string $a The first title. Converted to lower case.
 							 * @param string $b The second title. Converted to lower case.
+							 * @param Alphabet $alphabet The configured listing alphabet.
 							 * @return int The new order preference: -1 if $a is less than $b. 1 if $a is greater than $b. 0 if they are identical.
 							 */
 							$sort = apply_filters(
 								'alphalisting_item_sorting_comparator',
 								$default_sort,
 								$atitle,
-								$btitle
+								$btitle,
+								$alphabet
 							);
 
 							if ( is_int( $sort ) ) {

--- a/src/Query.php
+++ b/src/Query.php
@@ -837,9 +837,6 @@ class Query {
 		$key                        = $this->alphabet->get_key_for_offset( $this->current_letter_offset );
 		if ( isset( $this->matched_item_indices[ $key ] ) ) {
 			$this->current_letter_items = &$this->matched_item_indices[ $key ];
-			usort($this->current_letter_items, function ($a, $b) {
-				return strcasecmp($a['title'], $b['title']);
-			});
 		}
 		++$this->current_letter_offset;
 	}

--- a/src/Shortcode/QueryParts/GroupBy.php
+++ b/src/Shortcode/QueryParts/GroupBy.php
@@ -62,7 +62,7 @@ class GroupBy extends Extension {
             return $query;
         }
 
-        $this->add_hook( 'filter', 'alphalisting_item_index_letter', array( $this, 'index_by_last_word' ), 10, 3 );
+        $this->add_hook( 'filter', 'alphalisting_item_index_letter', array( $this, 'index_by_last_word' ), 10, 4 );
         $this->add_hook( 'filter', 'alphalisting_item_sorting_comparator', array( $this, 'sort_by_last_word' ), 10, 4 );
 
         if ( is_array( $query ) ) {

--- a/src/Shortcode/QueryParts/GroupBy.php
+++ b/src/Shortcode/QueryParts/GroupBy.php
@@ -13,6 +13,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
+use \eslin87\AlphaListing\Alphabet;
 use \eslin87\AlphaListing\Shortcode\Extension;
 use \eslin87\AlphaListing\Strings;
 
@@ -62,7 +63,7 @@ class GroupBy extends Extension {
         }
 
         $this->add_hook( 'filter', 'alphalisting_item_index_letter', array( $this, 'index_by_last_word' ), 10, 3 );
-        $this->add_hook( 'filter', 'alphalisting_item_sorting_comparator', array( $this, 'sort_by_last_word' ), 10, 3 );
+        $this->add_hook( 'filter', 'alphalisting_item_sorting_comparator', array( $this, 'sort_by_last_word' ), 10, 4 );
 
         if ( is_array( $query ) ) {
             // Distinguish this result from the default grouping in external cache implementations.
@@ -106,9 +107,10 @@ class GroupBy extends Extension {
      * @param int    $default_sort The existing comparison result.
      * @param string $first_title  The first title.
      * @param string $second_title The second title.
+     * @param Alphabet $alphabet    The configured listing alphabet.
      * @return int
      */
-    public function sort_by_last_word( int $default_sort, string $first_title, string $second_title ): int {
+    public function sort_by_last_word( int $default_sort, string $first_title, string $second_title, Alphabet $alphabet ): int {
         $first_word  = self::get_last_word( $first_title );
         $second_word = self::get_last_word( $second_title );
 
@@ -116,12 +118,12 @@ class GroupBy extends Extension {
             return $default_sort;
         }
 
-        $comparison = strcasecmp( $first_word, $second_word );
+        $comparison = $alphabet->compare_strings( $first_word, $second_word );
         if ( 0 !== $comparison ) {
             return $comparison <=> 0;
         }
 
-        return strcasecmp( $first_title, $second_title ) <=> 0;
+        return $default_sort;
     }
 
     /**

--- a/src/Shortcode/QueryParts/GroupBy.php
+++ b/src/Shortcode/QueryParts/GroupBy.php
@@ -61,7 +61,7 @@ class GroupBy extends Extension {
             return $query;
         }
 
-        $this->add_hook( 'filter', 'alphalisting_item_index_letter', array( $this, 'index_by_last_word' ), 10, 3 );
+        $this->add_hook( 'filter', 'alphalisting_item_index_letter', array( $this, 'index_by_last_word' ), 10, 4 );
         $this->add_hook( 'filter', 'alphalisting_item_sorting_comparator', array( $this, 'sort_by_last_word' ), 10, 3 );
 
         if ( is_array( $query ) ) {
@@ -78,20 +78,19 @@ class GroupBy extends Extension {
      * @param array  $letters Existing index letters.
      * @param mixed  $item    The post object or ID.
      * @param string $type    The listing type.
+     * @param string $title   The filtered title used to index the item.
      * @return array
      */
-    public function index_by_last_word( array $letters, $item, string $type ): array {
+    public function index_by_last_word( array $letters, $item, string $type, string $title = '' ): array {
         if ( 'posts' !== $type ) {
             return $letters;
         }
 
-        $post = $item instanceof \WP_Post ? $item : get_post( $item );
-        if ( ! $post instanceof \WP_Post ) {
+        if ( '' === $title ) {
             return $letters;
         }
 
-        $title = get_the_title( $post );
-        $word  = self::get_last_word( (string) $title );
+        $word = self::get_last_word( $title );
 
         if ( '' === $word ) {
             return $letters;

--- a/src/Shortcode/QueryParts/GroupBy.php
+++ b/src/Shortcode/QueryParts/GroupBy.php
@@ -142,9 +142,14 @@ class GroupBy extends Extension {
             return '';
         }
 
-        $word = (string) end( $words );
-        $word = preg_replace( '/^[\p{P}\p{S}]+|[\p{P}\p{S}]+$/u', '', $word );
+        for ( $index = count( $words ) - 1; $index >= 0; $index-- ) {
+            $word = preg_replace( '/^[\p{P}\p{S}]+|[\p{P}\p{S}]+$/u', '', (string) $words[ $index ] );
 
-        return is_string( $word ) ? $word : '';
+            if ( is_string( $word ) && '' !== $word ) {
+                return $word;
+            }
+        }
+
+        return '';
     }
 }

--- a/src/Shortcode/QueryParts/GroupBy.php
+++ b/src/Shortcode/QueryParts/GroupBy.php
@@ -1,0 +1,149 @@
+<?php
+/**
+ * Group By Query Part.
+ *
+ * @package alphalisting
+ */
+
+declare(strict_types=1);
+
+namespace eslin87\AlphaListing\Shortcode\QueryParts;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+use \eslin87\AlphaListing\Shortcode\Extension;
+use \eslin87\AlphaListing\Strings;
+
+/**
+ * Group posts by a selected part of their title.
+ */
+class GroupBy extends Extension {
+    /**
+     * The attribute for this Query Part.
+     *
+     * @var string
+     */
+    public $attribute_name = 'group-by';
+
+    /**
+     * The listing types supported by this Query Part.
+     *
+     * @var array<string>
+     */
+    public $display_types = array( 'posts' );
+
+    /**
+     * Sanitize the grouping mode.
+     *
+     * @param mixed $value      The value of the shortcode attribute.
+     * @param array $attributes The complete set of shortcode attributes.
+     * @return string
+     */
+    public function sanitize_attribute( $value, array $attributes ): string {
+        $value = is_string( $value ) ? strtolower( trim( $value ) ) : '';
+        return 'last-word' === $value ? 'last-word' : '';
+    }
+
+    /**
+     * Enable last-word grouping for post listings.
+     *
+     * @param mixed  $query      The query.
+     * @param string $display    The display/query type.
+     * @param string $key        The name of the attribute.
+     * @param mixed  $value      The shortcode attribute value.
+     * @param array  $attributes The complete set of shortcode attributes.
+     * @return mixed
+     */
+    public function shortcode_query_for_display_and_attribute( $query, string $display, string $key, $value, array $attributes ) {
+        if ( 'last-word' !== $value ) {
+            return $query;
+        }
+
+        $this->add_hook( 'filter', 'alphalisting_item_index_letter', array( $this, 'index_by_last_word' ), 10, 3 );
+        $this->add_hook( 'filter', 'alphalisting_item_sorting_comparator', array( $this, 'sort_by_last_word' ), 10, 3 );
+
+        if ( is_array( $query ) ) {
+            // Distinguish this result from the default grouping in external cache implementations.
+            $query['_alphalisting_group_by'] = 'last-word';
+        }
+
+        return $query;
+    }
+
+    /**
+     * Return the index letter from the last word of a post title.
+     *
+     * @param array  $letters Existing index letters.
+     * @param mixed  $item    The post object or ID.
+     * @param string $type    The listing type.
+     * @return array
+     */
+    public function index_by_last_word( array $letters, $item, string $type ): array {
+        if ( 'posts' !== $type ) {
+            return $letters;
+        }
+
+        $post = $item instanceof \WP_Post ? $item : get_post( $item );
+        if ( ! $post instanceof \WP_Post ) {
+            return $letters;
+        }
+
+        $title = get_the_title( $post );
+        $word  = self::get_last_word( (string) $title );
+
+        if ( '' === $word ) {
+            return $letters;
+        }
+
+        return array( Strings::maybe_mb_substr( $word, 0, 1 ) );
+    }
+
+    /**
+     * Sort titles by their last word, then by their complete title.
+     *
+     * @param int    $default_sort The existing comparison result.
+     * @param string $first_title  The first title.
+     * @param string $second_title The second title.
+     * @return int
+     */
+    public function sort_by_last_word( int $default_sort, string $first_title, string $second_title ): int {
+        $first_word  = self::get_last_word( $first_title );
+        $second_word = self::get_last_word( $second_title );
+
+        if ( '' === $first_word || '' === $second_word ) {
+            return $default_sort;
+        }
+
+        $comparison = strcasecmp( $first_word, $second_word );
+        if ( 0 !== $comparison ) {
+            return $comparison <=> 0;
+        }
+
+        return strcasecmp( $first_title, $second_title ) <=> 0;
+    }
+
+    /**
+     * Extract the final word from a title.
+     *
+     * @param string $title The title to parse.
+     * @return string
+     */
+    public static function get_last_word( string $title ): string {
+        $title = trim( wp_strip_all_tags( $title ) );
+        if ( '' === $title ) {
+            return '';
+        }
+
+        $words = preg_split( '/\s+/u', $title );
+        if ( ! is_array( $words ) || empty( $words ) ) {
+            return '';
+        }
+
+        $word = (string) end( $words );
+        $word = preg_replace( '/^[\p{P}\p{S}]+|[\p{P}\p{S}]+$/u', '', $word );
+
+        return is_string( $word ) ? $word : '';
+    }
+}

--- a/test/group-by-last-word.php
+++ b/test/group-by-last-word.php
@@ -98,6 +98,16 @@ if ( array( 'J' ) !== $letters ) {
     throw new RuntimeException( 'Expected the post to be indexed by the filtered title.' );
 }
 
+$zero_letters = $group_by->index_by_last_word( array( 'M' ), new WP_Post( 'Model 0' ), 'posts', 'Model 0' );
+if ( array( '0' ) !== $zero_letters ) {
+    throw new RuntimeException( 'Expected a zero-valued last-word index letter to be retained.' );
+}
+
+$indices_source = (string) file_get_contents( dirname( __DIR__ ) . '/src/Indices.php' );
+if ( ! str_contains( $indices_source, "static fn( \$letter ): bool => '' !== (string) \$letter" ) ) {
+    throw new RuntimeException( 'Expected index filtering to remove only empty index letters.' );
+}
+
 $term_letters = $group_by->index_by_last_word( array( 'Y' ), new WP_Post( 'Yassmin Abdel-Magied' ), 'terms', 'Yassmin Abdel-Magied' );
 if ( array( 'Y' ) !== $term_letters ) {
     throw new RuntimeException( 'Expected non-post listings to remain unchanged.' );

--- a/test/group-by-last-word.php
+++ b/test/group-by-last-word.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * Validate last-word extraction, indexing, and sorting.
+ *
+ * Run with: php test/group-by-last-word.php
+ */
+
+declare(strict_types=1);
+
+define( 'ABSPATH', __DIR__ . '/' );
+
+class WP_Post {
+    /**
+     * Post title used by the test stubs.
+     *
+     * @var string
+     */
+    public $post_title;
+
+    /**
+     * Build a test post.
+     *
+     * @param string $post_title Post title.
+     */
+    public function __construct( string $post_title ) {
+        $this->post_title = $post_title;
+    }
+}
+
+function wp_strip_all_tags( string $value ): string {
+    return strip_tags( $value );
+}
+
+function get_the_title( $post ): string {
+    return $post instanceof WP_Post ? $post->post_title : '';
+}
+
+function get_post( $post ) {
+    return $post;
+}
+
+require_once dirname( __DIR__ ) . '/vendor/autoload.php';
+
+use eslin87\AlphaListing\Shortcode\QueryParts\GroupBy;
+
+$examples = array(
+    'Yassmin Abdel-Magied'       => 'Abdel-Magied',
+    'Francesco Barberis Canonico' => 'Canonico',
+    'Raffaele La Capria'         => 'Capria',
+    '  Marina Abramovic  '       => 'Abramovic',
+    'David Adjaye, '             => 'Adjaye',
+    '<em>André Aciman</em>'      => 'Aciman',
+    ''                           => '',
+);
+
+foreach ( $examples as $title => $expected ) {
+    $actual = GroupBy::get_last_word( $title );
+    if ( $expected !== $actual ) {
+        throw new RuntimeException( "Expected '$expected' for '$title'; received '$actual'." );
+    }
+}
+
+$group_by = GroupBy::instance();
+if ( 'last-word' !== $group_by->sanitize_attribute( 'last-word', array() ) ) {
+    throw new RuntimeException( 'Expected the supported shortcode attribute value to be retained.' );
+}
+if ( '' !== $group_by->sanitize_attribute( 'unsupported', array() ) ) {
+    throw new RuntimeException( 'Expected an unsupported shortcode attribute value to be disabled.' );
+}
+
+$block_attributes = json_decode( (string) file_get_contents( dirname( __DIR__ ) . '/scripts/blocks/attributes.json' ), true );
+if ( 'last-word' !== $block_attributes['group-by']['enum'][1] || '' !== $block_attributes['group-by']['default'] ) {
+    throw new RuntimeException( 'Expected the block to expose last-word grouping as an opt-in attribute.' );
+}
+
+$block_editor = (string) file_get_contents( dirname( __DIR__ ) . '/scripts/blocks/edit.js' );
+if ( ! str_contains( $block_editor, "label={ __( 'Group by last word', 'alphalisting' ) }" )
+    || ! str_contains( $block_editor, "'group-by': enabled ? 'last-word' : ''" ) ) {
+    throw new RuntimeException( 'Expected the block to expose last-word grouping as a toggle.' );
+}
+
+$letters  = $group_by->index_by_last_word( array( 'Y' ), new WP_Post( 'Yassmin Abdel-Magied' ), 'posts' );
+if ( array( 'A' ) !== $letters ) {
+    throw new RuntimeException( 'Expected the post to be indexed under A.' );
+}
+
+$term_letters = $group_by->index_by_last_word( array( 'Y' ), new WP_Post( 'Yassmin Abdel-Magied' ), 'terms' );
+if ( array( 'Y' ) !== $term_letters ) {
+    throw new RuntimeException( 'Expected non-post listings to remain unchanged.' );
+}
+
+$titles = array( 'David Adjaye', 'Marina Abramovic', 'Cristina Acidini' );
+usort(
+    $titles,
+    function( string $first, string $second ) use ( $group_by ): int {
+        return $group_by->sort_by_last_word( 0, $first, $second );
+    }
+);
+
+$expected_titles = array( 'Marina Abramovic', 'Cristina Acidini', 'David Adjaye' );
+if ( $expected_titles !== $titles ) {
+    throw new RuntimeException( 'Expected titles to be sorted by last word.' );
+}
+
+echo "Group-by-last-word behavior is correct.\n";

--- a/test/group-by-last-word.php
+++ b/test/group-by-last-word.php
@@ -79,12 +79,17 @@ if ( ! str_contains( $block_editor, "label={ __( 'Group by last word', 'alphalis
     throw new RuntimeException( 'Expected the block to expose last-word grouping as a toggle.' );
 }
 
-$letters  = $group_by->index_by_last_word( array( 'Y' ), new WP_Post( 'Yassmin Abdel-Magied' ), 'posts' );
-if ( array( 'A' ) !== $letters ) {
-    throw new RuntimeException( 'Expected the post to be indexed under A.' );
+$letters = $group_by->index_by_last_word(
+    array( 'S' ),
+    new WP_Post( 'John Smith' ),
+    'posts',
+    'Smith, John'
+);
+if ( array( 'J' ) !== $letters ) {
+    throw new RuntimeException( 'Expected the post to be indexed by the filtered title.' );
 }
 
-$term_letters = $group_by->index_by_last_word( array( 'Y' ), new WP_Post( 'Yassmin Abdel-Magied' ), 'terms' );
+$term_letters = $group_by->index_by_last_word( array( 'Y' ), new WP_Post( 'Yassmin Abdel-Magied' ), 'terms', 'Yassmin Abdel-Magied' );
 if ( array( 'Y' ) !== $term_letters ) {
     throw new RuntimeException( 'Expected non-post listings to remain unchanged.' );
 }

--- a/test/group-by-last-word.php
+++ b/test/group-by-last-word.php
@@ -58,6 +58,10 @@ $examples = array(
     'Raffaele La Capria'         => 'Capria',
     '  Marina Abramovic  '       => 'Abramovic',
     'David Adjaye, '             => 'Adjaye',
+    'John Smith —'               => 'Smith',
+    'John Smith 🎉'              => 'Smith',
+    'John Smith — 🎉'            => 'Smith',
+    '— 🎉'                       => '',
     '<em>André Aciman</em>'      => 'Aciman',
     ''                           => '',
 );

--- a/test/group-by-last-word.php
+++ b/test/group-by-last-word.php
@@ -27,6 +27,14 @@ class WP_Post {
     }
 }
 
+function __( string $value ): string {
+    return $value;
+}
+
+function apply_filters( string $hook, $value ) {
+    return $value;
+}
+
 function wp_strip_all_tags( string $value ): string {
     return strip_tags( $value );
 }
@@ -41,6 +49,7 @@ function get_post( $post ) {
 
 require_once dirname( __DIR__ ) . '/vendor/autoload.php';
 
+use eslin87\AlphaListing\Alphabet;
 use eslin87\AlphaListing\Shortcode\QueryParts\GroupBy;
 
 $examples = array(
@@ -89,17 +98,29 @@ if ( array( 'Y' ) !== $term_letters ) {
     throw new RuntimeException( 'Expected non-post listings to remain unchanged.' );
 }
 
-$titles = array( 'David Adjaye', 'Marina Abramovic', 'Cristina Acidini' );
+$alphabet = new Alphabet();
+$titles   = array( 'David Adjaye', 'Marina Abramovic', 'Cristina Acidini' );
 usort(
     $titles,
-    function( string $first, string $second ) use ( $group_by ): int {
-        return $group_by->sort_by_last_word( 0, $first, $second );
+    function( string $first, string $second ) use ( $group_by, $alphabet ): int {
+        return $group_by->sort_by_last_word( $alphabet->compare_strings( $first, $second ), $first, $second, $alphabet );
     }
 );
 
 $expected_titles = array( 'Marina Abramovic', 'Cristina Acidini', 'David Adjaye' );
 if ( $expected_titles !== $titles ) {
     throw new RuntimeException( 'Expected titles to be sorted by last word.' );
+}
+
+$accented_titles = array( 'Anna Ézard', 'Bea éclair' );
+usort(
+    $accented_titles,
+    function( string $first, string $second ) use ( $group_by, $alphabet ): int {
+        return $group_by->sort_by_last_word( $alphabet->compare_strings( $first, $second ), $first, $second, $alphabet );
+    }
+);
+if ( array( 'Bea éclair', 'Anna Ézard' ) !== $accented_titles ) {
+    throw new RuntimeException( 'Expected equivalent accented letters to be sorted by their remaining characters.' );
 }
 
 echo "Group-by-last-word behavior is correct.\n";


### PR DESCRIPTION
### Motivation

- Provide an option to group and sort post listings by the last word of the post title so users can create indexes like surname-based or trailing-word catalogs. 

### Description

- Add a new shortcode/block attribute `group-by` with support for the value `last-word` and register it via `Shortcode\QueryParts\GroupBy`. 
- Implement `GroupBy` to index posts by the last word and to register a comparator filter for sorting by last word while falling back to full-title ordering. 
- Expose the feature in the block editor by adding a `group-by` attribute to `scripts/blocks/attributes.json` and a `ToggleControl` in `scripts/blocks/edit.js`, and add i18n strings to `languages/alphalisting.pot`. 
- Remove the inline per-letter `usort` in `src/Query.php` so ordering can be provided by the registered comparator hooks. 
- Update `README.md` and `readme.txt` to document the `group-by="last-word"` option and add a test script at `test/group-by-last-word.php` to validate extraction, indexing, and sorting behavior. 

### Testing

- Ran the new test with `php test/group-by-last-word.php` which completed successfully and printed the success message. 
- Verified `GroupBy::get_last_word()` against multiple title examples via the test script, and confirmed `sanitize_attribute()` returns expected values. 
- Confirmed the block attributes JSON and block editor toggle text are present by checking `scripts/blocks/attributes.json` and `scripts/blocks/edit.js` in the test script.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fe1ef6b9588321bca1db20c0c43d11)