### PR TITLE
Honor filtered titles when grouping by last word

### DIFF
--- a/src/Indices.php
+++ b/src/Indices.php
@@ -108,8 +108,9 @@ class Indices extends Singleton implements Extension {
 		 * @param array  $indices The current indices
 		 * @param mixed  $item The item
 		 * @param string $item_type The type of the listing.
+		 * @param string $title The filtered title used to index the item.
 		 */
-		$index_letters = apply_filters( 'alphalisting-item-index-letter', array( $index ), $item, $type ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
+		$index_letters = apply_filters( 'alphalisting-item-index-letter', array( $index ), $item, $type, $title ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
 
 		/**
 		 * Modify the index/indices to group this item under
@@ -119,8 +120,9 @@ class Indices extends Singleton implements Extension {
 		 * @param array  $indices The current indices
 		 * @param mixed  $item The item
 		 * @param string $item_type The type of the listing.
+		 * @param string $title The filtered title used to index the item.
 		 */
-		$index_letters = apply_filters( 'alphalisting_item_index_letter', $index_letters, $item, $type );
+		$index_letters = apply_filters( 'alphalisting_item_index_letter', $index_letters, $item, $type, $title );
 		$index_letters = array_unique( array_filter( $index_letters ) );
 
 		foreach ( $index_letters as $letter ) {

--- a/src/Shortcode/QueryParts/GroupBy.php
+++ b/src/Shortcode/QueryParts/GroupBy.php
@@ -61,7 +61,7 @@ class GroupBy extends Extension {
             return $query;
         }
 
-        $this->add_hook( 'filter', 'alphalisting_item_index_letter', array( $this, 'index_by_last_word' ), 10, 3 );
+        $this->add_hook( 'filter', 'alphalisting_item_index_letter', array( $this, 'index_by_last_word' ), 10, 4 );
         $this->add_hook( 'filter', 'alphalisting_item_sorting_comparator', array( $this, 'sort_by_last_word' ), 10, 3 );
 
         if ( is_array( $query ) ) {
@@ -78,20 +78,19 @@ class GroupBy extends Extension {
      * @param array  $letters Existing index letters.
      * @param mixed  $item    The post object or ID.
      * @param string $type    The listing type.
+     * @param string $title   The filtered title used to index the item.
      * @return array
      */
-    public function index_by_last_word( array $letters, $item, string $type ): array {
+    public function index_by_last_word( array $letters, $item, string $type, string $title = '' ): array {
         if ( 'posts' !== $type ) {
             return $letters;
         }
 
-        $post = $item instanceof \WP_Post ? $item : get_post( $item );
-        if ( ! $post instanceof \WP_Post ) {
+        if ( '' === $title ) {
             return $letters;
         }
 
-        $title = get_the_title( $post );
-        $word  = self::get_last_word( (string) $title );
+        $word = self::get_last_word( $title );
 
         if ( '' === $word ) {
             return $letters;

--- a/test/group-by-last-word.php
+++ b/test/group-by-last-word.php
@@ -79,12 +79,17 @@ if ( ! str_contains( $block_editor, "label={ __( 'Group by last word', 'alphalis
     throw new RuntimeException( 'Expected the block to expose last-word grouping as a toggle.' );
 }
 
-$letters  = $group_by->index_by_last_word( array( 'Y' ), new WP_Post( 'Yassmin Abdel-Magied' ), 'posts' );
-if ( array( 'A' ) !== $letters ) {
-    throw new RuntimeException( 'Expected the post to be indexed under A.' );
+$letters = $group_by->index_by_last_word(
+    array( 'S' ),
+    new WP_Post( 'John Smith' ),
+    'posts',
+    'Smith, John'
+);
+if ( array( 'J' ) !== $letters ) {
+    throw new RuntimeException( 'Expected the post to be indexed by the filtered title.' );
 }
 
-$term_letters = $group_by->index_by_last_word( array( 'Y' ), new WP_Post( 'Yassmin Abdel-Magied' ), 'terms' );
+$term_letters = $group_by->index_by_last_word( array( 'Y' ), new WP_Post( 'Yassmin Abdel-Magied' ), 'terms', 'Yassmin Abdel-Magied' );
 if ( array( 'Y' ) !== $term_letters ) {
     throw new RuntimeException( 'Expected non-post listings to remain unchanged.' );
 }


### PR DESCRIPTION
### Motivation

- Ensure any external filters that rewrite item titles (for display or indexing) are respected when deriving index buckets for the `group-by="last-word"` option so the displayed title, bucket, and ordering agree. 

### Description

- Pass the filtered listing title through the existing item-index hooks by adding the `$title` parameter to both `alphalisting-item-index-letter` and `alphalisting_item_index_letter` calls in `src/Indices.php`. 
- Update `src/Shortcode/QueryParts/GroupBy.php` to register `index_by_last_word` with 4 hook args and to derive the last-word bucket from the filtered title instead of re-reading the original post title. 
- Extend `index_by_last_word()` signature to accept an optional `$title` parameter and short-circuit when the filtered title is not provided. 
- Add/adjust regression coverage in `test/group-by-last-word.php` to assert that a title rewritten from `John Smith` to `Smith, John` is indexed into the expected bucket.

### Testing

- Ran `composer install --no-interaction` which completed successfully. 
- Ran the regression `php test/group-by-last-word.php` which exercised last-word extraction, indexing via the filtered title, and comparator behavior and completed successfully. 
- Ran a PHP syntax check `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l` which reported no syntax errors for the modified files. 
- Ran `git diff --check` to ensure no whitespace or patch issues, which returned clean results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a7dd1f92db88321bd69d492a53e9e76)