### PR TITLE
Preserve zero-valued last-word index letters

### DIFF
--- a/src/Indices.php
+++ b/src/Indices.php
@@ -123,7 +123,12 @@ class Indices extends Singleton implements Extension {
 		 * @param string $title The filtered title used to index the item.
 		 */
 		$index_letters = apply_filters( 'alphalisting_item_index_letter', $index_letters, $item, $type, $title );
-		$index_letters = array_unique( array_filter( $index_letters ) );
+        $index_letters = array_unique(
+            array_filter(
+                $index_letters,
+                static fn( $letter ): bool => '' !== (string) $letter
+            )
+        );
 
 		foreach ( $index_letters as $letter ) {
 			$indices[ $alphabet->get_letter_for_key( $letter ) ][] = array(

--- a/test/group-by-last-word.php
+++ b/test/group-by-last-word.php
@@ -98,6 +98,16 @@ if ( array( 'J' ) !== $letters ) {
     throw new RuntimeException( 'Expected the post to be indexed by the filtered title.' );
 }
 
+$zero_letters = $group_by->index_by_last_word( array( 'M' ), new WP_Post( 'Model 0' ), 'posts', 'Model 0' );
+if ( array( '0' ) !== $zero_letters ) {
+    throw new RuntimeException( 'Expected a zero-valued last-word index letter to be retained.' );
+}
+
+$indices_source = (string) file_get_contents( dirname( __DIR__ ) . '/src/Indices.php' );
+if ( ! str_contains( $indices_source, "static fn( \$letter ): bool => '' !== (string) \$letter" ) ) {
+    throw new RuntimeException( 'Expected index filtering to remove only empty index letters.' );
+}
+
 $term_letters = $group_by->index_by_last_word( array( 'Y' ), new WP_Post( 'Yassmin Abdel-Magied' ), 'terms', 'Yassmin Abdel-Magied' );
 if ( array( 'Y' ) !== $term_letters ) {
     throw new RuntimeException( 'Expected non-post listings to remain unchanged.' );


### PR DESCRIPTION
### Motivation

- Prevent items whose last word is the string "0" (for example `Model 0`) from being removed during index-letter filtering when `group-by="last-word"` is enabled.  
- Ensure index filtering removes only empty strings while leaving valid single-character keys (including numeric `"0"`) intact so posts stay in the expected numeric/unknown bucket.

### Description

- Replace the generic `array_filter()` call in `src/Indices.php` with a callback that keeps any non-empty string: `array_filter($index_letters, static fn($letter): bool => '' !== (string) $letter)`, wrapped in `array_unique()` to preserve uniqueness.  
- Add regression coverage to `test/group-by-last-word.php` that asserts a title ending in `0` yields the index letter `"0"` and that the `Indices` source contains the new filtering predicate.  
- Keep all behavior limited to index-letter filtering so other indexing and grouping logic is unchanged.

### Testing

- Ran `composer install --no-interaction --no-progress` and dependency autoloading completed successfully.  
- Ran the new test with `php test/group-by-last-word.php` and it completed successfully printing the expected success message.  
- Ran PHP lint across relevant files with `php -l` and the project returned no syntax errors.  
- Verified `php -l src/Indices.php` and `php -l test/group-by-last-word.php` both succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a7dd82fb4e083218ed7b75cd2708d43)